### PR TITLE
feat(cartridge): Mapper trait and PPU CHR routing through the cartridge

### DIFF
--- a/docs/debugging/MAPPER_TRAIT_REFACTOR.md
+++ b/docs/debugging/MAPPER_TRAIT_REFACTOR.md
@@ -28,7 +28,8 @@ current mirroring on every nametable access.
 | Contra | UxROM, CHR RAM | Blank blue screen | Correct title screen |
 | SMB3 | MMC3, CHR ROM | Blank blue screen | Opening curtain; bottom half black until the MMC3 IRQ lane lands (#3) |
 | mario.nes | NROM | Title screen | Byte-identical to before |
-| Zelda / Final Fantasy | MMC1, CHR RAM | Blank / partial | Byte-identical to before (the old PPU array already behaved as unbanked CHR RAM); whatever blocks them is not CHR |
+| Final Fantasy | MMC1, CHR RAM | Intro text | Byte-identical to before (the old PPU array already behaved as unbanked CHR RAM) |
+| Zelda | MMC1, CHR RAM | Blank blue at 900 frames | Byte-identical to before. Rendering is enabled (`$2001` = `0x1E`) but the palette is never written, so the game has not reached its PPU init; a CPU-side or NMI-path symptom for another lane, not CHR |
 
 ### Why the dead code did not help
 
@@ -161,3 +162,77 @@ black lower region until #3 lands, Zelda unchanged from before.
 3. Add `pub mod mapperN;` and a match arm in `Cartridge::build_mapper`.
 4. Add unit tests with `mapper::test_util::tagged_rom` so bank arithmetic is
    checked without a ROM image.
+
+## Appendix: reproducing the frame diff
+
+The before/after table was produced with a throwaway cargo project outside
+the repo that depends on `nes-emu` by path, runs a ROM for N frames, and
+dumps the raw 256x240 RGB buffer. Build it twice, once against a
+`git archive main` extraction and once against the branch, then `cmp` the
+dumps and convert them to PNG.
+
+`Cargo.toml`:
+
+```toml
+[package]
+name = "frame-harness"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[dependencies]
+nes-emu = { path = "/path/to/nes-emu" }
+```
+
+`src/main.rs`:
+
+```rust
+use nes_emu::cartridge::Cartridge;
+use nes_emu::input::ControllerButton;
+use nes_emu::system::System;
+use std::{env, fs};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let rom = &args[1];
+    let frames: usize = args[2].parse().unwrap();
+    let out = &args[3];
+    // Optional: tap Start at the given frame so title screens advance
+    let start_at: Option<usize> = args.get(4).map(|s| s.parse().unwrap());
+
+    let cart = Cartridge::load_from_file(rom).unwrap();
+    let mut system = System::new();
+    system.load_cartridge(cart);
+    for f in 0..frames {
+        if let Some(s) = start_at {
+            if f == s {
+                system.controller1.press(ControllerButton::START);
+            } else if f == s + 10 {
+                system.controller1.release(ControllerButton::START);
+            }
+        }
+        system.run_frame();
+    }
+    fs::write(out, system.get_frame_buffer()).unwrap();
+}
+```
+
+`topng.py` (stdlib only):
+
+```python
+import struct, sys, zlib
+W, H = 256, 240
+raw = open(sys.argv[1], 'rb').read()
+rows = b''.join(b'\x00' + raw[y * W * 3:(y + 1) * W * 3] for y in range(H))
+def chunk(t, d):
+    return struct.pack('>I', len(d)) + t + d + struct.pack('>I', zlib.crc32(t + d) & 0xffffffff)
+with open(sys.argv[2], 'wb') as f:
+    f.write(b'\x89PNG\r\n\x1a\n')
+    f.write(chunk(b'IHDR', struct.pack('>IIBBBBB', W, H, 8, 2, 0, 0, 0)))
+    f.write(chunk(b'IDAT', zlib.compress(rows)))
+    f.write(chunk(b'IEND', b''))
+```
+
+Frame counts used: SMB 240/600, Zelda 400/900, SMB3 500/900 (Start at 500),
+TMNT 400 and 700 (Start at 400), Final Fantasy 400, Contra 300.

--- a/docs/debugging/MAPPER_TRAIT_REFACTOR.md
+++ b/docs/debugging/MAPPER_TRAIT_REFACTOR.md
@@ -1,0 +1,163 @@
+# Mapper Trait Refactor and PPU CHR Routing
+
+**Date:** 2026-09-04
+**Type:** Architectural Refactor
+**Severity:** Critical Bug Fix (CHR bank switching never reached the PPU)
+**Status:** Complete
+**Tracking:** GitHub issue #2, Phase 2 of docs/plans/ACCURACY_ROADMAP.md
+
+## Executive Summary
+
+Before this change `System::load_cartridge` copied the first 8 KB of CHR ROM
+into a private PPU array once, at load time. Every mapper CHR bank write
+(MMC1 `$A000/$C000`, MMC3 `$8001`, CNROM `$8000`) updated cartridge state
+that nothing ever read, so any game with more than 8 KB of CHR rendered every
+tile from bank 0. Mirroring was likewise copied once from the iNES header.
+
+The cartridge is now a boxed `Mapper` trait object. The PPU fetches every
+pattern-table byte through it, writes CHR RAM through it, and asks it for the
+current mirroring on every nametable access.
+
+## Background
+
+### Symptoms (headless, 256x240 frame dumps, before vs after)
+
+| ROM | Board | Before | After |
+|-----|-------|--------|-------|
+| TMNT | MMC3, CHR ROM | Multicoloured garbage where the logo should be | Correct title screen and in-game overworld |
+| Contra | UxROM, CHR RAM | Blank blue screen | Correct title screen |
+| SMB3 | MMC3, CHR ROM | Blank blue screen | Opening curtain; bottom half black until the MMC3 IRQ lane lands (#3) |
+| mario.nes | NROM | Title screen | Byte-identical to before |
+| Zelda / Final Fantasy | MMC1, CHR RAM | Blank / partial | Byte-identical to before (the old PPU array already behaved as unbanked CHR RAM); whatever blocks them is not CHR |
+
+### Why the dead code did not help
+
+`src/cartridge/mapper4.rs` (MMC3) and `mapper5.rs` (MMC5) existed but were
+never referenced. The inline `match self.mapper` in `cartridge/mod.rs` only
+knew mappers 0, 1 and 65; everything else took the "unknown mapper" fallback
+that maps the last 32 KB of PRG. The MMC3 file also used addresses relative
+to `$6000` and had no read arm for `$E000-$FFFF`.
+
+## Design
+
+### The trait (`src/cartridge/mapper.rs`)
+
+```rust
+pub trait Mapper: Send {
+    fn cpu_read(&mut self, addr: u16) -> u8;        // $4020-$FFFF
+    fn cpu_write(&mut self, addr: u16, value: u8);
+    fn ppu_read(&mut self, addr: u16) -> u8;        // $0000-$1FFF
+    fn ppu_write(&mut self, addr: u16, value: u8);
+    fn mirroring(&self) -> Mirroring;
+    fn irq_pending(&self) -> bool { false }
+    fn clear_irq(&mut self) {}
+    fn clock_scanline(&mut self) {}
+}
+```
+
+Design choices:
+
+- **Boxed, not generic.** `Cartridge` holds `Box<dyn Mapper>`; `System`
+  holds `Option<Cartridge>`. One vtable call per bus access is nothing next
+  to the rest of the emulator and keeps `System` a plain struct.
+- **`&mut self` on reads.** MMC3 and MMC5 observe PPU address lines and MMC5
+  clears its IRQ flag on `$5204` reads, so reads must be able to mutate.
+- **Absolute CPU addresses.** Every mapper sees the real `$4020-$FFFF`
+  address. The old code passed `addr - 0x8000`, which is why `mapper4.rs`
+  had drifted to a `$6000`-relative convention.
+- **PRG RAM lives in the mapper.** `System` used to serve `$6000-$7FFF`
+  itself for every board. Each mapper now owns an 8 KB `prg_ram` so boards
+  can gate it (MMC3 `$A001`).
+- **CHR RAM lives in the mapper.** `Chr::new` allocates 8 KB of RAM when the
+  header reports zero CHR banks and makes `ppu_write` effective. Bank
+  arithmetic applies to RAM too, wrapping to the 8 KB.
+- **`Send`.** `System` is shared with the audio thread through `Arc<Mutex>`
+  in `main.rs`; the bound keeps that compiling.
+- **`NullMapper`.** Used by `System` when no cartridge is loaded so the PPU
+  can always be given a mapper.
+
+### Wiring choice: pass the mapper into the PPU
+
+Two options were considered for getting the PPU to the cartridge:
+
+1. Give the PPU a callback or an `Rc<RefCell<dyn Mapper>>`.
+2. Keep ownership in `System` and pass `&mut dyn Mapper` into
+   `Ppu::step`, `Ppu::read_register` and `Ppu::write_register`.
+
+Option 2 was chosen. It matches where CPU-side reads already live, needs no
+interior mutability, and makes the borrow explicit. `System::ppu_and_mapper`
+performs the split borrow:
+
+```rust
+fn ppu_and_mapper(&mut self) -> (&mut Ppu, &mut dyn Mapper) {
+    let mapper: &mut dyn Mapper = match self.cartridge.as_mut() {
+        Some(cart) => cart.mapper.as_mut(),
+        None => &mut self.null_mapper,
+    };
+    (&mut self.ppu, mapper)
+}
+```
+
+The parameter is threaded through `read_vram`, `write_vram`, the four
+`fetch_*` pipeline functions and `fetch_sprites`. `Ppu::vram` (16 KB) became
+`Ppu::nametable_ram` (4 KB): the PPU no longer holds any pattern data, and
+`mirror_nametable_addr(addr, mirroring)` returns an index into that array
+using the mirroring the mapper reports at that moment.
+
+### Per-mapper files
+
+| File | Board | Notes |
+|------|-------|-------|
+| `mapper0.rs` | NROM | Also the fallback for unknown mapper numbers (warning logged once at load). Oversized images expose their last 32 KB, as the old fallback did. |
+| `mapper1.rs` | MMC1 | Shift register, PRG modes 0-3, CHR 4 KB/8 KB modes, mirroring from the control register. Control powers up as `0x0C` plus the header's mirroring bits so nothing changes until the game writes it. |
+| `mapper2.rs` | UxROM | 16 KB switchable low bank, fixed last bank, CHR RAM. New. |
+| `mapper3.rs` | CNROM | 8 KB CHR bank select. New. |
+| `mapper4.rs` | MMC3 | Rewritten to absolute addresses; `clock_scanline` is byte-for-byte the old counter. `$A001` bit 7 enables PRG RAM (default enabled), bit 6 write-protects. Nothing calls `clock_scanline` yet; issue #3 wires the A12 edge and delivers the IRQ. |
+| `mapper5.rs` | MMC5 | Wired for the first time. PRG/CHR modes, multiplier, ExRAM, register file. ExRAM nametables, fill mode and the vertical split are recorded but not rendered (the PPU has no per-table nametable hook); `mirroring()` approximates `$5105`. |
+| `mapper65.rs` | Irem H3001 | Moved out of `mod.rs`. CHR registers corrected from `$9000-$9007` to `$B000-$B007` (nesdev); the old offset never mattered because CHR never reached the PPU. |
+
+### Behaviour changes beyond CHR routing
+
+- Out-of-range PRG bank reads wrap to the ROM size instead of returning 0.
+  This is what the address lines do on hardware and is what the MMC3 code
+  already did.
+- MMC3 `$E000-$FFFF` reads now work (the dead file returned 0).
+- Mapper 65 CHR register address corrected (see table).
+
+## Verification
+
+### Headless (`cargo test`, 48 tests)
+
+- Mapper unit tests with synthetic bank-tagged ROMs (`tagged_rom` in
+  `mapper.rs`): MMC1 shift register, reset bit, PRG modes 0-3, CHR modes,
+  mirroring; MMC3 bank registers in both PRG and CHR modes, PRG RAM protect,
+  mirroring, scanline counter reload/decrement/pending/acknowledge; NROM,
+  UxROM, CNROM, H3001 and MMC5 bank arithmetic.
+- iNES parsing: mapper number, battery flag, CHR RAM allocation, unknown
+  mapper fallback, header and truncation errors.
+- PPU-level tests in `src/ppu/mod.rs` that prove the wiring, not just the
+  arithmetic: a `$2007` pattern read follows a CNROM bank switch, a `$2007`
+  write reaches the mapper's CHR RAM, `fetch_pattern_low/high` read the
+  mapper, and an MMC3 `$A000` write changes nametable mirroring for the very
+  next access.
+- Frame dumps: a scratch harness ran each ROM for several hundred frames
+  against a build of `main` and this branch and diffed the RGB buffers (table
+  above).
+
+### Human visual pass still needed
+
+Run the SDL binary with SMB (`mario.nes`), Zelda, SMB3 and TMNT. Expect SMB
+unchanged, TMNT title and gameplay tiles correct, SMB3 curtain correct with a
+black lower region until #3 lands, Zelda unchanged from before.
+
+## How to add a mapper
+
+1. Create `src/cartridge/mapperN.rs` with a struct holding `prg_rom`,
+   `Chr` (via `Chr::new(chr_rom)`), `prg_ram` and the board's registers.
+2. Implement `Mapper`. Use `prg_read(&self.prg_rom, offset)` and
+   `self.chr.read(offset)` so bank offsets wrap safely. Return the live
+   mirroring from `mirroring()`; override `irq_pending`, `clear_irq` and
+   `clock_scanline` only if the board has an IRQ.
+3. Add `pub mod mapperN;` and a match arm in `Cartridge::build_mapper`.
+4. Add unit tests with `mapper::test_util::tagged_rom` so bank arithmetic is
+   checked without a ROM image.

--- a/src/bin/test_output.rs
+++ b/src/bin/test_output.rs
@@ -13,7 +13,7 @@ fn main() {
     println!("Loading ROM: {}", rom_path);
 
     let cartridge = Cartridge::load_from_file(rom_path).unwrap();
-    println!("ROM loaded. Mapper: {}", cartridge.mapper);
+    println!("ROM loaded. Mapper: {}", cartridge.mapper_id);
 
     let mut system = System::new();
     system.load_cartridge(cartridge);

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -1,0 +1,118 @@
+//! The `Mapper` trait: the cartridge-side view of the CPU and PPU buses.
+//!
+//! `System` owns a boxed mapper (inside `Cartridge`) and routes every CPU
+//! access in $4020-$FFFF to `cpu_read`/`cpu_write`. The PPU is handed
+//! `&mut dyn Mapper` on every `step`/register access and routes every
+//! pattern-table access ($0000-$1FFF) through `ppu_read`/`ppu_write`, so CHR
+//! bank switching is visible to rendering immediately. Nametable RAM stays in
+//! the PPU; the PPU asks `mirroring()` per access.
+
+use super::Mirroring;
+
+pub trait Mapper: Send {
+    /// CPU bus read for $4020-$FFFF (PRG ROM, PRG RAM, mapper registers).
+    fn cpu_read(&mut self, addr: u16) -> u8;
+
+    /// CPU bus write for $4020-$FFFF.
+    fn cpu_write(&mut self, addr: u16, value: u8);
+
+    /// PPU bus read for $0000-$1FFF (pattern tables, CHR ROM or CHR RAM).
+    fn ppu_read(&mut self, addr: u16) -> u8;
+
+    /// PPU bus write for $0000-$1FFF. Ignored by CHR ROM boards.
+    fn ppu_write(&mut self, addr: u16, value: u8);
+
+    /// Current nametable mirroring. Queried per nametable access.
+    fn mirroring(&self) -> Mirroring;
+
+    /// True while the mapper is asserting its IRQ line.
+    fn irq_pending(&self) -> bool {
+        false
+    }
+
+    /// Acknowledge the mapper IRQ.
+    fn clear_irq(&mut self) {}
+
+    /// Scanline clock for mappers with a scanline counter (MMC3, MMC5).
+    /// No-op for everything else.
+    fn clock_scanline(&mut self) {}
+}
+
+/// Mapper used when no cartridge is loaded: open bus everywhere.
+#[derive(Default)]
+pub struct NullMapper;
+
+impl Mapper for NullMapper {
+    fn cpu_read(&mut self, _addr: u16) -> u8 {
+        0
+    }
+
+    fn cpu_write(&mut self, _addr: u16, _value: u8) {}
+
+    fn ppu_read(&mut self, _addr: u16) -> u8 {
+        0
+    }
+
+    fn ppu_write(&mut self, _addr: u16, _value: u8) {}
+
+    fn mirroring(&self) -> Mirroring {
+        Mirroring::Horizontal
+    }
+}
+
+/// CHR storage shared by the simple mappers: either CHR ROM from the image or
+/// an 8 KB CHR RAM allocated when the header reports zero CHR banks.
+pub(crate) struct Chr {
+    pub data: Vec<u8>,
+    pub is_ram: bool,
+}
+
+impl Chr {
+    pub fn new(chr_rom: Vec<u8>) -> Self {
+        if chr_rom.is_empty() {
+            Chr {
+                data: vec![0; 0x2000],
+                is_ram: true,
+            }
+        } else {
+            Chr {
+                data: chr_rom,
+                is_ram: false,
+            }
+        }
+    }
+
+    /// Read from an absolute CHR offset, wrapping to the CHR size.
+    pub fn read(&self, offset: usize) -> u8 {
+        self.data[offset % self.data.len()]
+    }
+
+    pub fn write(&mut self, offset: usize, value: u8) {
+        if self.is_ram {
+            let len = self.data.len();
+            self.data[offset % len] = value;
+        }
+    }
+}
+
+/// Read from PRG ROM at an absolute offset, wrapping to the ROM size.
+pub(crate) fn prg_read(prg_rom: &[u8], offset: usize) -> u8 {
+    if prg_rom.is_empty() {
+        0
+    } else {
+        prg_rom[offset % prg_rom.len()]
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_util {
+    /// Build a ROM image of `banks` banks of `bank_size` bytes where every
+    /// byte of bank `i` equals `i`, so a read tells you which bank it hit.
+    pub fn tagged_rom(banks: usize, bank_size: usize) -> Vec<u8> {
+        let mut rom = Vec::with_capacity(banks * bank_size);
+        for bank in 0..banks {
+            rom.extend(vec![bank as u8; bank_size]);
+        }
+        rom
+    }
+}

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -16,6 +16,11 @@ pub trait Mapper: Send {
     /// CPU bus write for $4020-$FFFF.
     fn cpu_write(&mut self, addr: u16, value: u8);
 
+    /// Side-effect-free CPU read used by debuggers and the test harness.
+    /// Must return the same bytes as `cpu_read` for PRG RAM and PRG ROM,
+    /// but must not touch mapper registers that change state when read.
+    fn cpu_peek(&self, addr: u16) -> u8;
+
     /// PPU bus read for $0000-$1FFF (pattern tables, CHR ROM or CHR RAM).
     fn ppu_read(&mut self, addr: u16) -> u8;
 
@@ -48,6 +53,10 @@ impl Mapper for NullMapper {
     }
 
     fn cpu_write(&mut self, _addr: u16, _value: u8) {}
+
+    fn cpu_peek(&self, _addr: u16) -> u8 {
+        0
+    }
 
     fn ppu_read(&mut self, _addr: u16) -> u8 {
         0

--- a/src/cartridge/mapper0.rs
+++ b/src/cartridge/mapper0.rs
@@ -1,0 +1,126 @@
+//! Mapper 0 (NROM). Also the fallback for unsupported mapper numbers.
+//!
+//! PRG: 16 KB (mirrored at $C000) or 32 KB. Larger images, which only occur
+//! for unknown mappers falling back here, expose their last 32 KB so the
+//! reset vector is reachable. CHR: 8 KB ROM, or 8 KB RAM when the header
+//! reports no CHR.
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper0 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+    mirroring: Mirroring,
+}
+
+impl Mapper0 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mapper0 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            mirroring,
+        }
+    }
+
+    fn prg_offset(&self, addr: u16) -> usize {
+        let rel = (addr - 0x8000) as usize;
+        let len = self.prg_rom.len();
+        if len <= 0x8000 {
+            // 16 KB mirrors via the modulo in prg_read; 32 KB maps directly.
+            rel
+        } else {
+            // Oversized image (unknown mapper fallback): map the last 32 KB.
+            len - 0x8000 + rel
+        }
+    }
+}
+
+impl Mapper for Mapper0 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xFFFF => prg_read(&self.prg_rom, self.prg_offset(addr)),
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0x8000..=0xFFFF => log::warn!("Attempting to write to ROM at {:04X}", addr),
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read((addr & 0x1FFF) as usize)
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        self.chr.write((addr & 0x1FFF) as usize, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        self.mirroring
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    #[test]
+    fn prg_16k_mirrors_into_upper_half() {
+        let mut m = Mapper0::new(
+            tagged_rom(1, 0x4000),
+            tagged_rom(1, 0x2000),
+            Mirroring::Vertical,
+        );
+        let mut prg = tagged_rom(1, 0x4000);
+        prg[0x3FFC] = 0x34;
+        let mut m2 = Mapper0::new(prg, vec![], Mirroring::Vertical);
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xC000), 0);
+        assert_eq!(m2.cpu_read(0xBFFC), 0x34);
+        assert_eq!(m2.cpu_read(0xFFFC), 0x34);
+    }
+
+    #[test]
+    fn prg_32k_maps_directly() {
+        let mut m = Mapper0::new(tagged_rom(2, 0x4000), vec![], Mirroring::Horizontal);
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xC000), 1);
+        assert_eq!(m.cpu_read(0xFFFF), 1);
+    }
+
+    #[test]
+    fn oversized_prg_exposes_last_32k() {
+        let mut m = Mapper0::new(tagged_rom(8, 0x4000), vec![], Mirroring::Horizontal);
+        assert_eq!(m.cpu_read(0x8000), 6);
+        assert_eq!(m.cpu_read(0xC000), 7);
+    }
+
+    #[test]
+    fn chr_rom_is_read_only_and_chr_ram_is_writable() {
+        let mut rom = Mapper0::new(vec![0; 0x4000], vec![0xAB; 0x2000], Mirroring::Horizontal);
+        rom.ppu_write(0x0010, 0x01);
+        assert_eq!(rom.ppu_read(0x0010), 0xAB);
+
+        let mut ram = Mapper0::new(vec![0; 0x4000], vec![], Mirroring::Horizontal);
+        assert_eq!(ram.ppu_read(0x1FFF), 0);
+        ram.ppu_write(0x1FFF, 0x5A);
+        assert_eq!(ram.ppu_read(0x1FFF), 0x5A);
+    }
+
+    #[test]
+    fn prg_ram_round_trips() {
+        let mut m = Mapper0::new(vec![0; 0x4000], vec![], Mirroring::Horizontal);
+        m.cpu_write(0x6123, 0x77);
+        assert_eq!(m.cpu_read(0x6123), 0x77);
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+    }
+}

--- a/src/cartridge/mapper0.rs
+++ b/src/cartridge/mapper0.rs
@@ -40,6 +40,10 @@ impl Mapper0 {
 
 impl Mapper for Mapper0 {
     fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
             0x8000..=0xFFFF => prg_read(&self.prg_rom, self.prg_offset(addr)),

--- a/src/cartridge/mapper1.rs
+++ b/src/cartridge/mapper1.rs
@@ -106,6 +106,10 @@ impl Mapper1 {
 
 impl Mapper for Mapper1 {
     fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
             0x8000..=0xFFFF => prg_read(&self.prg_rom, self.prg_offset(addr)),

--- a/src/cartridge/mapper1.rs
+++ b/src/cartridge/mapper1.rs
@@ -1,0 +1,284 @@
+//! Mapper 1 (MMC1 / SxROM).
+//!
+//! Registers are loaded one bit at a time through a 5-bit shift register at
+//! $8000-$FFFF; the fifth write commits to the register selected by address
+//! bits 13-14. Control ($8000): mirroring (bits 0-1), PRG mode (2-3), CHR mode
+//! (4). CHR bank 0 ($A000), CHR bank 1 ($C000), PRG bank ($E000).
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper1 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+
+    shift_register: u8,
+    shift_count: u8,
+    control: u8,
+    chr_bank_0: u8,
+    chr_bank_1: u8,
+    prg_bank: u8,
+}
+
+impl Mapper1 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, header_mirroring: Mirroring) -> Self {
+        // Power-on: 16 KB PRG mode with the last bank fixed at $C000 (mode 3).
+        // Seed the mirroring bits from the header so nothing changes until
+        // the game writes the control register.
+        let mirror_bits = match header_mirroring {
+            Mirroring::Vertical => 0x02,
+            Mirroring::Horizontal => 0x03,
+            Mirroring::SingleScreenLower => 0x00,
+            Mirroring::SingleScreenUpper => 0x01,
+            Mirroring::FourScreen => 0x03,
+        };
+        Mapper1 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            shift_register: 0,
+            shift_count: 0,
+            control: 0x0C | mirror_bits,
+            chr_bank_0: 0,
+            chr_bank_1: 0,
+            prg_bank: 0,
+        }
+    }
+
+    fn prg_mode(&self) -> u8 {
+        (self.control >> 2) & 0x03
+    }
+
+    fn chr_4k_mode(&self) -> bool {
+        self.control & 0x10 != 0
+    }
+
+    fn prg_offset(&self, addr: u16) -> usize {
+        let rel = (addr - 0x8000) as usize;
+        let prg_banks = (self.prg_rom.len() / 0x4000).max(1);
+        match self.prg_mode() {
+            0 | 1 => {
+                // 32 KB mode: ignore the low bit of the bank number
+                (self.prg_bank & 0xFE) as usize * 0x4000 + rel
+            }
+            2 => {
+                // First bank fixed at $8000, switchable bank at $C000
+                if rel < 0x4000 {
+                    rel
+                } else {
+                    self.prg_bank as usize * 0x4000 + (rel - 0x4000)
+                }
+            }
+            _ => {
+                // Switchable bank at $8000, last bank fixed at $C000
+                if rel < 0x4000 {
+                    self.prg_bank as usize * 0x4000 + rel
+                } else {
+                    (prg_banks - 1) * 0x4000 + (rel - 0x4000)
+                }
+            }
+        }
+    }
+
+    fn chr_offset(&self, addr: u16) -> usize {
+        let addr = (addr & 0x1FFF) as usize;
+        if self.chr_4k_mode() {
+            if addr < 0x1000 {
+                self.chr_bank_0 as usize * 0x1000 + addr
+            } else {
+                self.chr_bank_1 as usize * 0x1000 + (addr - 0x1000)
+            }
+        } else {
+            (self.chr_bank_0 & 0x1E) as usize * 0x1000 + addr
+        }
+    }
+
+    fn write_register(&mut self, addr: u16, value: u8) {
+        match addr & 0x6000 {
+            0x0000 => self.control = value,
+            0x2000 => self.chr_bank_0 = value,
+            0x4000 => self.chr_bank_1 = value,
+            _ => self.prg_bank = value & 0x0F,
+        }
+    }
+}
+
+impl Mapper for Mapper1 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xFFFF => prg_read(&self.prg_rom, self.prg_offset(addr)),
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0x8000..=0xFFFF => {
+                if value & 0x80 != 0 {
+                    // Reset: clear the shift register and force PRG mode 3
+                    self.shift_register = 0;
+                    self.shift_count = 0;
+                    self.control |= 0x0C;
+                } else {
+                    self.shift_register = (self.shift_register >> 1) | ((value & 1) << 4);
+                    self.shift_count += 1;
+                    if self.shift_count == 5 {
+                        let data = self.shift_register;
+                        self.write_register(addr, data);
+                        self.shift_register = 0;
+                        self.shift_count = 0;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        let offset = self.chr_offset(addr);
+        self.chr.write(offset, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        match self.control & 0x03 {
+            0 => Mirroring::SingleScreenLower,
+            1 => Mirroring::SingleScreenUpper,
+            2 => Mirroring::Vertical,
+            _ => Mirroring::Horizontal,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    /// Serially load a 5-bit value into the MMC1 register at `addr`.
+    fn load(m: &mut Mapper1, addr: u16, value: u8) {
+        for i in 0..5 {
+            m.cpu_write(addr, (value >> i) & 1);
+        }
+    }
+
+    fn mmc1() -> Mapper1 {
+        // 8 x 16 KB PRG, 8 x 4 KB CHR
+        Mapper1::new(
+            tagged_rom(8, 0x4000),
+            tagged_rom(8, 0x1000),
+            Mirroring::Horizontal,
+        )
+    }
+
+    #[test]
+    fn power_on_state_is_mode_3_with_header_mirroring() {
+        let mut m = mmc1();
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xC000), 7);
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+        let v = Mapper1::new(tagged_rom(2, 0x4000), vec![], Mirroring::Vertical);
+        assert_eq!(v.mirroring(), Mirroring::Vertical);
+    }
+
+    #[test]
+    fn shift_register_commits_on_fifth_write() {
+        let mut m = mmc1();
+        // Four writes: nothing committed yet
+        for _ in 0..4 {
+            m.cpu_write(0xE000, 1);
+        }
+        assert_eq!(m.cpu_read(0x8000), 0);
+        m.cpu_write(0xE000, 0); // value = 0b01111 = 15 -> wraps to bank 7
+        assert_eq!(m.cpu_read(0x8000), 7);
+    }
+
+    #[test]
+    fn reset_bit_clears_shift_and_forces_mode_3() {
+        let mut m = mmc1();
+        load(&mut m, 0x8000, 0x00); // 32 KB mode, single screen lower
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenLower);
+        m.cpu_write(0xE000, 1);
+        m.cpu_write(0xE000, 0x80);
+        assert_eq!(m.prg_mode(), 3);
+        assert_eq!(m.shift_count, 0);
+    }
+
+    #[test]
+    fn prg_mode_3_switches_low_bank_and_fixes_last() {
+        let mut m = mmc1();
+        load(&mut m, 0x8000, 0x0C);
+        load(&mut m, 0xE000, 3);
+        assert_eq!(m.cpu_read(0x8000), 3);
+        assert_eq!(m.cpu_read(0xBFFF), 3);
+        assert_eq!(m.cpu_read(0xC000), 7);
+    }
+
+    #[test]
+    fn prg_mode_2_fixes_first_bank_and_switches_high() {
+        let mut m = mmc1();
+        load(&mut m, 0x8000, 0x08);
+        load(&mut m, 0xE000, 5);
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xC000), 5);
+    }
+
+    #[test]
+    fn prg_32k_mode_ignores_low_bank_bit() {
+        let mut m = mmc1();
+        load(&mut m, 0x8000, 0x00);
+        load(&mut m, 0xE000, 5);
+        assert_eq!(m.cpu_read(0x8000), 4);
+        assert_eq!(m.cpu_read(0xC000), 5);
+        load(&mut m, 0x8000, 0x04); // mode 1 behaves like mode 0
+        assert_eq!(m.cpu_read(0x8000), 4);
+    }
+
+    #[test]
+    fn chr_8k_mode_uses_even_bank_pair() {
+        let mut m = mmc1();
+        load(&mut m, 0x8000, 0x0C); // CHR 8 KB mode
+        load(&mut m, 0xA000, 5); // low bit ignored -> banks 4,5
+        assert_eq!(m.ppu_read(0x0000), 4);
+        assert_eq!(m.ppu_read(0x1000), 5);
+        load(&mut m, 0xC000, 2); // ignored in 8 KB mode
+        assert_eq!(m.ppu_read(0x1000), 5);
+    }
+
+    #[test]
+    fn chr_4k_mode_switches_halves_independently() {
+        let mut m = mmc1();
+        load(&mut m, 0x8000, 0x1C); // CHR 4 KB mode
+        load(&mut m, 0xA000, 6);
+        load(&mut m, 0xC000, 1);
+        assert_eq!(m.ppu_read(0x0000), 6);
+        assert_eq!(m.ppu_read(0x0FFF), 6);
+        assert_eq!(m.ppu_read(0x1000), 1);
+        assert_eq!(m.ppu_read(0x1FFF), 1);
+    }
+
+    #[test]
+    fn mirroring_follows_control_register() {
+        let mut m = mmc1();
+        load(&mut m, 0x8000, 0x0E);
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        load(&mut m, 0x8000, 0x0F);
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+        load(&mut m, 0x8000, 0x0D);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenUpper);
+    }
+
+    #[test]
+    fn chr_ram_board_writes_through_bank() {
+        let mut m = Mapper1::new(tagged_rom(2, 0x4000), vec![], Mirroring::Horizontal);
+        m.ppu_write(0x0123, 0x99);
+        assert_eq!(m.ppu_read(0x0123), 0x99);
+        assert_eq!(m.ppu_read(0x1123), 0);
+    }
+}

--- a/src/cartridge/mapper2.rs
+++ b/src/cartridge/mapper2.rs
@@ -1,0 +1,99 @@
+//! Mapper 2 (UxROM).
+//!
+//! $8000-$BFFF: switchable 16 KB PRG bank (written to $8000-$FFFF).
+//! $C000-$FFFF: fixed to the last 16 KB bank. CHR is 8 KB RAM on real boards.
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper2 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+    mirroring: Mirroring,
+    prg_bank: u8,
+}
+
+impl Mapper2 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mapper2 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            mirroring,
+            prg_bank: 0,
+        }
+    }
+
+    fn last_bank_offset(&self) -> usize {
+        self.prg_rom.len().saturating_sub(0x4000)
+    }
+}
+
+impl Mapper for Mapper2 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xBFFF => {
+                let offset = self.prg_bank as usize * 0x4000 + (addr - 0x8000) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            0xC000..=0xFFFF => {
+                let offset = self.last_bank_offset() + (addr - 0xC000) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0x8000..=0xFFFF => self.prg_bank = value & 0x0F,
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read((addr & 0x1FFF) as usize)
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        self.chr.write((addr & 0x1FFF) as usize, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        self.mirroring
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    #[test]
+    fn switchable_low_bank_and_fixed_high_bank() {
+        let mut m = Mapper2::new(tagged_rom(8, 0x4000), vec![], Mirroring::Vertical);
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xC000), 7);
+        m.cpu_write(0x8000, 5);
+        assert_eq!(m.cpu_read(0x8000), 5);
+        assert_eq!(m.cpu_read(0xBFFF), 5);
+        assert_eq!(m.cpu_read(0xFFFF), 7);
+    }
+
+    #[test]
+    fn bank_wraps_to_rom_size() {
+        let mut m = Mapper2::new(tagged_rom(4, 0x4000), vec![], Mirroring::Vertical);
+        m.cpu_write(0xFFFF, 6);
+        assert_eq!(m.cpu_read(0x8000), 2);
+    }
+
+    #[test]
+    fn chr_ram_is_writable() {
+        let mut m = Mapper2::new(tagged_rom(2, 0x4000), vec![], Mirroring::Vertical);
+        m.ppu_write(0x0000, 0x42);
+        assert_eq!(m.ppu_read(0x0000), 0x42);
+    }
+}

--- a/src/cartridge/mapper2.rs
+++ b/src/cartridge/mapper2.rs
@@ -32,6 +32,10 @@ impl Mapper2 {
 
 impl Mapper for Mapper2 {
     fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
             0x8000..=0xBFFF => {

--- a/src/cartridge/mapper3.rs
+++ b/src/cartridge/mapper3.rs
@@ -28,6 +28,10 @@ impl Mapper3 {
 
 impl Mapper for Mapper3 {
     fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
             0x8000..=0xFFFF => prg_read(&self.prg_rom, (addr - 0x8000) as usize),

--- a/src/cartridge/mapper3.rs
+++ b/src/cartridge/mapper3.rs
@@ -1,0 +1,101 @@
+//! Mapper 3 (CNROM).
+//!
+//! PRG is NROM-style (16 KB mirrored or 32 KB). Writes to $8000-$FFFF select
+//! an 8 KB CHR ROM bank (low 2 bits on real CNROM; larger values wrap).
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper3 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+    mirroring: Mirroring,
+    chr_bank: u8,
+}
+
+impl Mapper3 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mapper3 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            mirroring,
+            chr_bank: 0,
+        }
+    }
+}
+
+impl Mapper for Mapper3 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xFFFF => prg_read(&self.prg_rom, (addr - 0x8000) as usize),
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0x8000..=0xFFFF => self.chr_bank = value & 0x03,
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        let offset = self.chr_bank as usize * 0x2000 + (addr & 0x1FFF) as usize;
+        self.chr.read(offset)
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        let offset = self.chr_bank as usize * 0x2000 + (addr & 0x1FFF) as usize;
+        self.chr.write(offset, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        self.mirroring
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    #[test]
+    fn chr_bank_select() {
+        let mut m = Mapper3::new(
+            tagged_rom(2, 0x4000),
+            tagged_rom(4, 0x2000),
+            Mirroring::Vertical,
+        );
+        assert_eq!(m.ppu_read(0x0000), 0);
+        assert_eq!(m.ppu_read(0x1FFF), 0);
+        m.cpu_write(0x8000, 2);
+        assert_eq!(m.ppu_read(0x0000), 2);
+        assert_eq!(m.ppu_read(0x1FFF), 2);
+        m.cpu_write(0xFFFF, 3);
+        assert_eq!(m.ppu_read(0x0800), 3);
+        // CHR ROM: writes are ignored
+        m.ppu_write(0x0800, 0x11);
+        assert_eq!(m.ppu_read(0x0800), 3);
+    }
+
+    #[test]
+    fn prg_is_nrom_style() {
+        let mut m = Mapper3::new(
+            tagged_rom(1, 0x4000),
+            tagged_rom(2, 0x2000),
+            Mirroring::Vertical,
+        );
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xC000), 0);
+        let mut m32 = Mapper3::new(
+            tagged_rom(2, 0x4000),
+            tagged_rom(2, 0x2000),
+            Mirroring::Vertical,
+        );
+        assert_eq!(m32.cpu_read(0xC000), 1);
+    }
+}

--- a/src/cartridge/mapper4.rs
+++ b/src/cartridge/mapper4.rs
@@ -135,6 +135,10 @@ impl Mapper4 {
 
 impl Mapper for Mapper4 {
     fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => {
                 if self.prg_ram_enabled {

--- a/src/cartridge/mapper4.rs
+++ b/src/cartridge/mapper4.rs
@@ -1,210 +1,414 @@
-// MMC3 (Mapper 4) implementation
-// Used by many popular games like Super Mario Bros 2 & 3, Mega Man 3-6, etc.
+//! Mapper 4 (MMC3 / TxROM).
+//!
+//! Used by Super Mario Bros 2 and 3, Mega Man 3-6, TMNT, Kirby's Adventure.
+//!
+//! Registers (CPU addresses; even/odd selects the register within each pair):
+//!   $8000 bank select, $8001 bank data,
+//!   $A000 mirroring,   $A001 PRG RAM protect,
+//!   $C000 IRQ latch,   $C001 IRQ reload,
+//!   $E000 IRQ disable, $E001 IRQ enable.
+//!
+//! `clock_scanline` implements the scanline counter. Nothing calls it yet;
+//! wiring it to the PPU A12 edge and delivering the IRQ is a follow-up.
+
+use super::mapper::{Chr, Mapper};
+use super::Mirroring;
 
 pub struct Mapper4 {
     prg_rom: Vec<u8>,
-    chr_rom: Vec<u8>,
+    chr: Chr,
     prg_ram: [u8; 0x2000],
-    
+
     // Bank registers
     bank_select: u8,
     bank_data: [u8; 8],
-    
-    // PRG RAM protect
-    prg_ram_protect: bool,
-    
+
+    // PRG RAM control ($A001): bit 7 enable, bit 6 write protect.
+    // Hardware powers up undefined; enabled by default so games that never
+    // write $A001 keep working (matches the pre-trait System behaviour).
+    prg_ram_enabled: bool,
+    prg_ram_write_protect: bool,
+
     // Mirroring
+    four_screen: bool,
     mirroring: u8,
-    
+
     // IRQ
     irq_enabled: bool,
     irq_counter: u8,
     irq_latch: u8,
     irq_reload: bool,
-    pub irq_pending: bool,
-    
-    // Current PRG banks
+    irq_pending: bool,
+
+    // Resolved PRG bank offsets for $8000, $A000, $C000, $E000
     prg_banks: [usize; 4],
-    
-    // Current CHR banks
+
+    // Resolved CHR bank offsets for each 1 KB slot
     chr_banks: [usize; 8],
 }
 
 impl Mapper4 {
-    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>) -> Self {
-        let prg_banks = [
-            0,
-            0x2000,
-            prg_rom.len() - 0x4000,
-            prg_rom.len() - 0x2000,
-        ];
-        
-        let chr_banks = [0; 8];
-        
-        Self {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, header_mirroring: Mirroring) -> Self {
+        let mut mapper = Self {
             prg_rom,
-            chr_rom,
+            chr: Chr::new(chr_rom),
             prg_ram: [0; 0x2000],
             bank_select: 0,
             bank_data: [0; 8],
-            prg_ram_protect: false,
-            mirroring: 0,
+            prg_ram_enabled: true,
+            prg_ram_write_protect: false,
+            four_screen: matches!(header_mirroring, Mirroring::FourScreen),
+            mirroring: match header_mirroring {
+                Mirroring::Horizontal => 1,
+                _ => 0,
+            },
             irq_enabled: false,
             irq_counter: 0,
             irq_latch: 0,
             irq_reload: false,
             irq_pending: false,
-            prg_banks,
-            chr_banks,
+            prg_banks: [0; 4],
+            chr_banks: [0; 8],
+        };
+        // Bank registers power up cleared; derive the slot offsets from them.
+        mapper.update_banks();
+        mapper
+    }
+
+    fn update_banks(&mut self) {
+        let prg_mode = (self.bank_select >> 6) & 0x01;
+        let chr_mode = (self.bank_select >> 7) & 0x01;
+
+        let prg_len = self.prg_rom.len().max(1);
+        let r6 = (self.bank_data[6] as usize) * 0x2000 % prg_len;
+        let r7 = (self.bank_data[7] as usize) * 0x2000 % prg_len;
+        let second_last = self.prg_rom.len().saturating_sub(0x4000);
+        let last = self.prg_rom.len().saturating_sub(0x2000);
+
+        if prg_mode == 0 {
+            self.prg_banks = [r6, r7, second_last, last];
+        } else {
+            self.prg_banks = [second_last, r7, r6, last];
+        }
+
+        let chr_len = self.chr.data.len();
+        let bank = |value: u8| (value as usize) * 0x400 % chr_len;
+        let r0 = self.bank_data[0];
+        let r1 = self.bank_data[1];
+        let r2 = self.bank_data[2];
+        let r3 = self.bank_data[3];
+        let r4 = self.bank_data[4];
+        let r5 = self.bank_data[5];
+
+        if chr_mode == 0 {
+            // Two 2 KB banks at $0000-$0FFF, four 1 KB banks at $1000-$1FFF
+            self.chr_banks = [
+                bank(r0 & 0xFE),
+                bank(r0 | 0x01),
+                bank(r1 & 0xFE),
+                bank(r1 | 0x01),
+                bank(r2),
+                bank(r3),
+                bank(r4),
+                bank(r5),
+            ];
+        } else {
+            // Four 1 KB banks at $0000-$0FFF, two 2 KB banks at $1000-$1FFF
+            self.chr_banks = [
+                bank(r2),
+                bank(r3),
+                bank(r4),
+                bank(r5),
+                bank(r0 & 0xFE),
+                bank(r0 | 0x01),
+                bank(r1 & 0xFE),
+                bank(r1 | 0x01),
+            ];
         }
     }
-    
-    pub fn read_prg(&self, addr: u16) -> u8 {
+
+    fn chr_offset(&self, addr: u16) -> usize {
+        let slot = ((addr & 0x1FFF) / 0x400) as usize;
+        self.chr_banks[slot] + (addr & 0x3FF) as usize
+    }
+}
+
+impl Mapper for Mapper4 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
         match addr {
-            0x0000..=0x1FFF => {
-                if self.prg_ram_protect {
+            0x6000..=0x7FFF => {
+                if self.prg_ram_enabled {
                     self.prg_ram[(addr & 0x1FFF) as usize]
                 } else {
                     0
                 }
             }
-            0x2000..=0x3FFF => {
-                self.prg_rom[self.prg_banks[0] + (addr as usize & 0x1FFF)]
-            }
-            0x4000..=0x5FFF => {
-                self.prg_rom[self.prg_banks[1] + (addr as usize & 0x1FFF)]
-            }
-            0x6000..=0x7FFF => {
-                self.prg_rom[self.prg_banks[2] + (addr as usize & 0x1FFF)]
+            0x8000..=0xFFFF => {
+                if self.prg_rom.is_empty() {
+                    return 0;
+                }
+                let slot = ((addr - 0x8000) / 0x2000) as usize;
+                let offset = self.prg_banks[slot] + (addr & 0x1FFF) as usize;
+                self.prg_rom[offset % self.prg_rom.len()]
             }
             _ => 0,
         }
     }
-    
-    pub fn write_prg(&mut self, addr: u16, value: u8) {
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
         match addr {
-            0x0000..=0x1FFF => {
-                if self.prg_ram_protect {
+            0x6000..=0x7FFF => {
+                if self.prg_ram_enabled && !self.prg_ram_write_protect {
                     self.prg_ram[(addr & 0x1FFF) as usize] = value;
                 }
             }
-            0x2000..=0x3FFF if addr & 0x01 == 0 => {
-                // Bank select ($8000-$9FFE, even)
+            0x8000..=0x9FFF if addr & 0x01 == 0 => {
+                // Bank select
                 self.bank_select = value;
                 self.update_banks();
             }
-            0x2000..=0x3FFF => {
-                // Bank data ($8001-$9FFF, odd)
+            0x8000..=0x9FFF => {
+                // Bank data
                 let bank = self.bank_select & 0x07;
                 self.bank_data[bank as usize] = value;
                 self.update_banks();
             }
-            0x4000..=0x5FFF if addr & 0x01 == 0 => {
-                // Mirroring ($A000-$BFFE, even)
+            0xA000..=0xBFFF if addr & 0x01 == 0 => {
+                // Mirroring: 0 = vertical, 1 = horizontal
                 self.mirroring = value & 0x01;
             }
-            0x4000..=0x5FFF => {
-                // PRG RAM protect ($A001-$BFFF, odd)
-                self.prg_ram_protect = (value & 0x80) != 0;
+            0xA000..=0xBFFF => {
+                // PRG RAM protect
+                self.prg_ram_enabled = (value & 0x80) != 0;
+                self.prg_ram_write_protect = (value & 0x40) != 0;
             }
-            0x6000..=0x7FFF if addr & 0x01 == 0 => {
-                // IRQ latch ($C000-$DFFE, even)
+            0xC000..=0xDFFF if addr & 0x01 == 0 => {
+                // IRQ latch
                 self.irq_latch = value;
             }
-            0x6000..=0x7FFF => {
-                // IRQ reload ($C001-$DFFF, odd)
+            0xC000..=0xDFFF => {
+                // IRQ reload
                 self.irq_reload = true;
                 self.irq_counter = 0;
             }
-            0x8000..=0x9FFF if addr & 0x01 == 0 => {
-                // IRQ disable ($E000-$FFFE, even)
+            0xE000..=0xFFFF if addr & 0x01 == 0 => {
+                // IRQ disable (also acknowledges)
                 self.irq_enabled = false;
                 self.irq_pending = false;
             }
-            0x8000..=0x9FFF => {
-                // IRQ enable ($E001-$FFFF, odd)
+            0xE000..=0xFFFF => {
+                // IRQ enable
                 self.irq_enabled = true;
             }
             _ => {}
         }
     }
-    
-    pub fn read_chr(&self, addr: u16) -> u8 {
-        if self.chr_rom.is_empty() {
-            return 0; // CHR RAM
-        }
-        
-        let bank = (addr / 0x400) as usize;
-        let offset = (addr & 0x3FF) as usize;
-        let bank_addr = self.chr_banks[bank] + offset;
-        
-        if bank_addr < self.chr_rom.len() {
-            self.chr_rom[bank_addr]
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        let offset = self.chr_offset(addr);
+        self.chr.write(offset, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        if self.four_screen {
+            Mirroring::FourScreen
+        } else if self.mirroring == 0 {
+            Mirroring::Vertical
         } else {
-            0
+            Mirroring::Horizontal
         }
     }
-    
-    pub fn write_chr(&mut self, _addr: u16, _value: u8) {
-        // CHR ROM is read-only, but some games have CHR RAM
-        // TODO: Implement CHR RAM support
+
+    fn irq_pending(&self) -> bool {
+        self.irq_pending
     }
-    
-    pub fn clock_scanline(&mut self) {
+
+    fn clear_irq(&mut self) {
+        self.irq_pending = false;
+    }
+
+    fn clock_scanline(&mut self) {
         if self.irq_counter == 0 || self.irq_reload {
             self.irq_counter = self.irq_latch;
             self.irq_reload = false;
         } else {
             self.irq_counter -= 1;
         }
-        
+
         if self.irq_counter == 0 && self.irq_enabled {
             self.irq_pending = true;
         }
     }
-    
-    fn update_banks(&mut self) {
-        let prg_mode = (self.bank_select >> 6) & 0x01;
-        let chr_mode = (self.bank_select >> 7) & 0x01;
-        
-        // Update PRG banks
-        if prg_mode == 0 {
-            self.prg_banks[0] = (self.bank_data[6] as usize) * 0x2000 % self.prg_rom.len();
-            self.prg_banks[1] = (self.bank_data[7] as usize) * 0x2000 % self.prg_rom.len();
-            self.prg_banks[2] = self.prg_rom.len() - 0x4000;
-            self.prg_banks[3] = self.prg_rom.len() - 0x2000;
-        } else {
-            self.prg_banks[0] = self.prg_rom.len() - 0x4000;
-            self.prg_banks[1] = (self.bank_data[7] as usize) * 0x2000 % self.prg_rom.len();
-            self.prg_banks[2] = (self.bank_data[6] as usize) * 0x2000 % self.prg_rom.len();
-            self.prg_banks[3] = self.prg_rom.len() - 0x2000;
-        }
-        
-        // Update CHR banks
-        if !self.chr_rom.is_empty() {
-            if chr_mode == 0 {
-                self.chr_banks[0] = ((self.bank_data[0] & 0xFE) as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[1] = ((self.bank_data[0] | 0x01) as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[2] = ((self.bank_data[1] & 0xFE) as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[3] = ((self.bank_data[1] | 0x01) as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[4] = (self.bank_data[2] as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[5] = (self.bank_data[3] as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[6] = (self.bank_data[4] as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[7] = (self.bank_data[5] as usize) * 0x400 % self.chr_rom.len();
-            } else {
-                self.chr_banks[0] = (self.bank_data[2] as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[1] = (self.bank_data[3] as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[2] = (self.bank_data[4] as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[3] = (self.bank_data[5] as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[4] = ((self.bank_data[0] & 0xFE) as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[5] = ((self.bank_data[0] | 0x01) as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[6] = ((self.bank_data[1] & 0xFE) as usize) * 0x400 % self.chr_rom.len();
-                self.chr_banks[7] = ((self.bank_data[1] | 0x01) as usize) * 0x400 % self.chr_rom.len();
-            }
-        }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    /// 16 x 8 KB PRG banks, 64 x 1 KB CHR banks.
+    fn mmc3() -> Mapper4 {
+        Mapper4::new(
+            tagged_rom(16, 0x2000),
+            tagged_rom(64, 0x400),
+            Mirroring::Vertical,
+        )
     }
-    
-    pub fn get_mirroring(&self) -> u8 {
-        self.mirroring
+
+    fn set_bank(m: &mut Mapper4, mode_bits: u8, reg: u8, value: u8) {
+        m.cpu_write(0x8000, mode_bits | reg);
+        m.cpu_write(0x8001, value);
+    }
+
+    #[test]
+    fn power_on_prg_layout() {
+        let mut m = mmc3();
+        // R6 and R7 power up at 0; the upper two slots are fixed
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xA000), 0);
+        assert_eq!(m.cpu_read(0xC000), 14);
+        assert_eq!(m.cpu_read(0xE000), 15);
+        assert_eq!(m.cpu_read(0xFFFF), 15);
+    }
+
+    #[test]
+    fn prg_mode_0_switches_8000_and_a000() {
+        let mut m = mmc3();
+        set_bank(&mut m, 0x00, 6, 9);
+        set_bank(&mut m, 0x00, 7, 3);
+        assert_eq!(m.cpu_read(0x8000), 9);
+        assert_eq!(m.cpu_read(0xA000), 3);
+        assert_eq!(m.cpu_read(0xC000), 14);
+        assert_eq!(m.cpu_read(0xE000), 15);
+    }
+
+    #[test]
+    fn prg_mode_1_swaps_8000_and_c000() {
+        let mut m = mmc3();
+        set_bank(&mut m, 0x40, 6, 9);
+        set_bank(&mut m, 0x40, 7, 3);
+        assert_eq!(m.cpu_read(0x8000), 14);
+        assert_eq!(m.cpu_read(0xA000), 3);
+        assert_eq!(m.cpu_read(0xC000), 9);
+        assert_eq!(m.cpu_read(0xE000), 15);
+    }
+
+    #[test]
+    fn prg_bank_wraps_to_rom_size() {
+        let mut m = mmc3();
+        set_bank(&mut m, 0x00, 6, 17);
+        assert_eq!(m.cpu_read(0x8000), 1);
+    }
+
+    #[test]
+    fn chr_mode_0_layout() {
+        let mut m = mmc3();
+        set_bank(&mut m, 0x00, 0, 11); // 2 KB, low bit ignored -> 10,11
+        set_bank(&mut m, 0x00, 1, 20);
+        set_bank(&mut m, 0x00, 2, 30);
+        set_bank(&mut m, 0x00, 3, 31);
+        set_bank(&mut m, 0x00, 4, 32);
+        set_bank(&mut m, 0x00, 5, 33);
+        assert_eq!(m.ppu_read(0x0000), 10);
+        assert_eq!(m.ppu_read(0x0400), 11);
+        assert_eq!(m.ppu_read(0x0800), 20);
+        assert_eq!(m.ppu_read(0x0C00), 21);
+        assert_eq!(m.ppu_read(0x1000), 30);
+        assert_eq!(m.ppu_read(0x1400), 31);
+        assert_eq!(m.ppu_read(0x1800), 32);
+        assert_eq!(m.ppu_read(0x1C00), 33);
+        assert_eq!(m.ppu_read(0x1FFF), 33);
+    }
+
+    #[test]
+    fn chr_mode_1_layout() {
+        let mut m = mmc3();
+        set_bank(&mut m, 0x80, 0, 10);
+        set_bank(&mut m, 0x80, 1, 20);
+        set_bank(&mut m, 0x80, 2, 30);
+        set_bank(&mut m, 0x80, 3, 31);
+        set_bank(&mut m, 0x80, 4, 32);
+        set_bank(&mut m, 0x80, 5, 33);
+        assert_eq!(m.ppu_read(0x0000), 30);
+        assert_eq!(m.ppu_read(0x0400), 31);
+        assert_eq!(m.ppu_read(0x0800), 32);
+        assert_eq!(m.ppu_read(0x0C00), 33);
+        assert_eq!(m.ppu_read(0x1000), 10);
+        assert_eq!(m.ppu_read(0x1400), 11);
+        assert_eq!(m.ppu_read(0x1800), 20);
+        assert_eq!(m.ppu_read(0x1C00), 21);
+    }
+
+    #[test]
+    fn chr_ram_board_banks_within_8k() {
+        let mut m = Mapper4::new(tagged_rom(4, 0x2000), vec![], Mirroring::Vertical);
+        m.ppu_write(0x0000, 0x5A);
+        assert_eq!(m.ppu_read(0x0000), 0x5A);
+        // Bank 8 wraps onto bank 0 of the 8 KB RAM
+        set_bank(&mut m, 0x80, 2, 8);
+        assert_eq!(m.ppu_read(0x0000), 0x5A);
+    }
+
+    #[test]
+    fn mirroring_register() {
+        let mut m = mmc3();
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        m.cpu_write(0xA000, 1);
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+        m.cpu_write(0xA000, 0);
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        let f = Mapper4::new(tagged_rom(4, 0x2000), vec![], Mirroring::FourScreen);
+        assert_eq!(f.mirroring(), Mirroring::FourScreen);
+    }
+
+    #[test]
+    fn prg_ram_protect() {
+        let mut m = mmc3();
+        m.cpu_write(0x6000, 0x42);
+        assert_eq!(m.cpu_read(0x6000), 0x42);
+        m.cpu_write(0xA001, 0xC0); // enabled, write-protected
+        m.cpu_write(0x6000, 0x11);
+        assert_eq!(m.cpu_read(0x6000), 0x42);
+        m.cpu_write(0xA001, 0x00); // disabled
+        assert_eq!(m.cpu_read(0x6000), 0);
+    }
+
+    #[test]
+    fn irq_counter_reloads_then_counts_down_to_pending() {
+        let mut m = mmc3();
+        m.cpu_write(0xC000, 3); // latch
+        m.cpu_write(0xC001, 0); // reload
+        m.cpu_write(0xE001, 0); // enable
+
+        m.clock_scanline(); // reload -> 3
+        assert!(!m.irq_pending());
+        m.clock_scanline(); // 2
+        m.clock_scanline(); // 1
+        assert!(!m.irq_pending());
+        m.clock_scanline(); // 0 -> pending
+        assert!(Mapper::irq_pending(&m));
+
+        m.clear_irq();
+        assert!(!m.irq_pending());
+        m.clock_scanline(); // counter 0 -> reload to 3
+        assert_eq!(m.irq_counter, 3);
+    }
+
+    #[test]
+    fn irq_disable_acknowledges_and_stops_counter_from_asserting() {
+        let mut m = mmc3();
+        m.cpu_write(0xC000, 0);
+        m.cpu_write(0xC001, 0);
+        m.cpu_write(0xE001, 0);
+        m.clock_scanline(); // latch 0 -> pending immediately
+        assert!(Mapper::irq_pending(&m));
+        m.cpu_write(0xE000, 0);
+        assert!(!Mapper::irq_pending(&m));
+        m.clock_scanline();
+        assert!(!Mapper::irq_pending(&m));
     }
 }

--- a/src/cartridge/mapper5.rs
+++ b/src/cartridge/mapper5.rs
@@ -268,6 +268,15 @@ impl Mapper for Mapper5 {
         }
     }
 
+    fn cpu_peek(&self, addr: u16) -> u8 {
+        match addr {
+            // $5000-$5FFF registers have read side effects; never peek them.
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xFFFF => self.read_prg(addr - 0x8000),
+            _ => 0,
+        }
+    }
+
     fn cpu_write(&mut self, addr: u16, value: u8) {
         match addr {
             0x5000..=0x5FFF => self.write_register(addr, value),

--- a/src/cartridge/mapper5.rs
+++ b/src/cartridge/mapper5.rs
@@ -1,366 +1,254 @@
+//! Mapper 5 (MMC5 / ExROM).
+//!
+//! PRG and CHR banking, the multiplier, ExRAM and the register file are
+//! implemented. ExRAM-as-nametable, fill mode, the vertical split and the
+//! scanline IRQ are only partially modelled: the PPU has no hook for
+//! per-table nametable sources yet, so `mirroring()` approximates $5105 with
+//! the closest standard mirroring mode.
+
+use super::mapper::{Chr, Mapper};
+use super::Mirroring;
 
 pub struct Mapper5 {
     prg_rom: Vec<u8>,
-    chr_rom: Vec<u8>,
-    
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+
     // ExRAM - 1KB internal RAM for extended attributes and nametables
     exram: [u8; 0x400],
     exram_mode: u8,
-    
+
     // PRG banking
     prg_mode: u8,
-    prg_banks: [u8; 5],  // Up to 5 banks depending on mode
+    prg_banks: [u8; 5],
+    #[allow(dead_code)] // write protection is recorded but not enforced yet
     prg_ram_protect: [u8; 2],
-    
+
     // CHR banking
     chr_mode: u8,
-    chr_banks: [u16; 12],  // Up to 12 banks depending on mode
+    chr_banks: [u16; 12],
     upper_chr_bank_bits: u8,
-    
+
     // Nametable control
     nametable_mapping: [u8; 4],
+    #[allow(dead_code)] // fill mode needs a PPU nametable hook
     fill_mode_tile: u8,
+    #[allow(dead_code)]
     fill_mode_attr: u8,
-    
-    // Split screen control
+
+    // Split screen control (recorded, not rendered)
+    #[allow(dead_code)]
     vsplit_enabled: bool,
-    vsplit_side: bool,  // false = left, true = right
+    #[allow(dead_code)]
+    vsplit_side: bool,
+    #[allow(dead_code)]
     vsplit_tile: u8,
+    #[allow(dead_code)]
     vsplit_scroll: u8,
+    #[allow(dead_code)]
     vsplit_bank: u8,
-    in_split_area: bool,
-    
+
     // IRQ control
     irq_scanline: u8,
     irq_enabled: bool,
     irq_pending: bool,
     irq_in_frame: bool,
     scanline_counter: u8,
-    
+
     // PPU monitoring
     ppu_is_rendering: bool,
-    last_ppu_read: u16,
-    consecutive_nametable_reads: u8,
-    
+
     // Multiplication unit
     multiplicand_a: u8,
     multiplicand_b: u8,
 }
 
 impl Mapper5 {
-    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>) -> Self {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, header_mirroring: Mirroring) -> Self {
+        let nametable_mapping = match header_mirroring {
+            Mirroring::Vertical => [0, 1, 0, 1],
+            Mirroring::Horizontal => [0, 0, 1, 1],
+            Mirroring::SingleScreenLower => [0, 0, 0, 0],
+            Mirroring::SingleScreenUpper => [1, 1, 1, 1],
+            Mirroring::FourScreen => [0, 1, 2, 3],
+        };
+
         let mut mapper = Mapper5 {
             prg_rom,
-            chr_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
             exram: [0; 0x400],
             exram_mode: 0,
-            
-            prg_mode: 3,  // Default to mode 3
-            prg_banks: [0xFF, 0xFF, 0xFF, 0xFF, 0xFF],  // Default to last bank
+
+            prg_mode: 3,
+            prg_banks: [0xFF; 5],
             prg_ram_protect: [0; 2],
-            
+
             chr_mode: 0,
             chr_banks: [0; 12],
             upper_chr_bank_bits: 0,
-            
-            nametable_mapping: [0; 4],
+
+            nametable_mapping,
             fill_mode_tile: 0,
             fill_mode_attr: 0,
-            
+
             vsplit_enabled: false,
             vsplit_side: false,
             vsplit_tile: 0,
             vsplit_scroll: 0,
             vsplit_bank: 0,
-            in_split_area: false,
-            
+
             irq_scanline: 0,
             irq_enabled: false,
             irq_pending: false,
             irq_in_frame: false,
             scanline_counter: 0,
-            
+
             ppu_is_rendering: false,
-            last_ppu_read: 0,
-            consecutive_nametable_reads: 0,
-            
+
             multiplicand_a: 0,
             multiplicand_b: 0,
         };
-        
-        // Initialize PRG banks to point to last bank
-        let last_bank = (mapper.prg_rom.len() / 0x2000 - 1) as u8;
+
+        // Initialize the fixed slot to point at the last bank
+        let last_bank = (mapper.prg_rom.len() / 0x2000).saturating_sub(1) as u8;
         mapper.prg_banks[4] = last_bank;
-        
+
         mapper
     }
-    
-    pub fn read_prg(&self, addr: u16) -> u8 {
+
+    fn prg_read_at(&self, offset: usize) -> u8 {
+        if offset < self.prg_rom.len() {
+            self.prg_rom[offset]
+        } else {
+            0
+        }
+    }
+
+    /// `rel` is the offset from $8000.
+    fn read_prg(&self, rel: u16) -> u8 {
         match self.prg_mode {
             0 => {
                 // Mode 0: 32KB switchable
                 let bank = (self.prg_banks[4] >> 2) as usize;
-                let offset = bank * 0x8000 + (addr as usize);
-                if offset < self.prg_rom.len() {
-                    self.prg_rom[offset]
-                } else {
-                    0
-                }
+                self.prg_read_at(bank * 0x8000 + rel as usize)
             }
             1 => {
                 // Mode 1: 16KB + 16KB
-                match addr {
-                    0x0000..=0x3FFF => {
-                        let bank = (self.prg_banks[2] >> 1) as usize;
-                        let offset = bank * 0x4000 + (addr as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
-                    }
-                    0x4000..=0x7FFF => {
-                        let bank = (self.prg_banks[4] >> 1) as usize;
-                        let offset = bank * 0x4000 + ((addr - 0x4000) as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
-                    }
-                    _ => 0
+                if rel < 0x4000 {
+                    let bank = (self.prg_banks[2] >> 1) as usize;
+                    self.prg_read_at(bank * 0x4000 + rel as usize)
+                } else {
+                    let bank = (self.prg_banks[4] >> 1) as usize;
+                    self.prg_read_at(bank * 0x4000 + (rel - 0x4000) as usize)
                 }
             }
             2 => {
                 // Mode 2: 16KB + 8KB + 8KB
-                match addr {
+                match rel {
                     0x0000..=0x3FFF => {
                         let bank = (self.prg_banks[2] >> 1) as usize;
-                        let offset = bank * 0x4000 + (addr as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
+                        self.prg_read_at(bank * 0x4000 + rel as usize)
                     }
                     0x4000..=0x5FFF => {
                         let bank = self.prg_banks[3] as usize;
-                        let offset = bank * 0x2000 + ((addr - 0x4000) as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
+                        self.prg_read_at(bank * 0x2000 + (rel - 0x4000) as usize)
                     }
-                    0x6000..=0x7FFF => {
+                    _ => {
                         let bank = self.prg_banks[4] as usize;
-                        let offset = bank * 0x2000 + ((addr - 0x6000) as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
+                        self.prg_read_at(bank * 0x2000 + (rel - 0x6000) as usize)
                     }
-                    _ => 0
                 }
             }
-            3 => {
+            _ => {
                 // Mode 3: 8KB + 8KB + 8KB + 8KB
-                let bank_index = (addr / 0x2000) as usize;
+                let bank_index = (rel / 0x2000) as usize;
                 let bank = self.prg_banks[bank_index + 1] as usize;
-                let offset = bank * 0x2000 + ((addr & 0x1FFF) as usize);
-                if offset < self.prg_rom.len() {
-                    self.prg_rom[offset]
-                } else {
-                    0
-                }
+                self.prg_read_at(bank * 0x2000 + (rel & 0x1FFF) as usize)
             }
-            _ => 0
         }
     }
-    
-    pub fn write_prg(&mut self, addr: u16, value: u8) {
+
+    fn chr_offset(&self, addr: u16) -> usize {
+        let addr = addr & 0x1FFF;
+        let (bank_index, bank_size): (usize, usize) = match self.chr_mode {
+            0 => ((addr / 0x2000) as usize * 8, 0x2000),
+            1 => ((addr / 0x1000) as usize * 4, 0x1000),
+            2 => ((addr / 0x800) as usize * 2, 0x800),
+            _ => ((addr / 0x400) as usize, 0x400),
+        };
+        // In the wider modes the register that selects a bank is the last
+        // register of the group (e.g. $5127 for 8 KB mode).
+        let reg = (bank_index + bank_size / 0x400 - 1).min(11);
+        let bank = self.chr_banks[reg] as usize;
+        bank * bank_size + (addr as usize & (bank_size - 1))
+    }
+
+    fn write_register(&mut self, addr: u16, value: u8) {
         match addr {
             0x5000..=0x5015 => {
                 // Audio registers (not implemented)
             }
-            0x5100 => {
-                // PRG mode
-                self.prg_mode = value & 0x03;
-            }
-            0x5101 => {
-                // CHR mode
-                self.chr_mode = value & 0x03;
-            }
-            0x5102 => {
-                // PRG-RAM protect 1
-                self.prg_ram_protect[0] = value & 0x03;
-            }
-            0x5103 => {
-                // PRG-RAM protect 2
-                self.prg_ram_protect[1] = value & 0x03;
-            }
-            0x5104 => {
-                // ExRAM mode
-                self.exram_mode = value & 0x03;
-            }
+            0x5100 => self.prg_mode = value & 0x03,
+            0x5101 => self.chr_mode = value & 0x03,
+            0x5102 => self.prg_ram_protect[0] = value & 0x03,
+            0x5103 => self.prg_ram_protect[1] = value & 0x03,
+            0x5104 => self.exram_mode = value & 0x03,
             0x5105 => {
-                // Nametable mapping
                 self.nametable_mapping[0] = value & 0x03;
                 self.nametable_mapping[1] = (value >> 2) & 0x03;
                 self.nametable_mapping[2] = (value >> 4) & 0x03;
                 self.nametable_mapping[3] = (value >> 6) & 0x03;
             }
-            0x5106 => {
-                // Fill mode tile
-                self.fill_mode_tile = value;
-            }
-            0x5107 => {
-                // Fill mode attribute
-                self.fill_mode_attr = value & 0x03;
-            }
+            0x5106 => self.fill_mode_tile = value,
+            0x5107 => self.fill_mode_attr = value & 0x03,
             0x5113..=0x5117 => {
-                // PRG banks
                 let bank_index = (addr - 0x5113) as usize;
-                self.prg_banks[bank_index] = value;
+                self.prg_banks[bank_index] = value & 0x7F;
             }
             0x5120..=0x512B => {
-                // CHR banks
                 let bank_index = (addr - 0x5120) as usize;
-                self.chr_banks[bank_index] = value as u16 | ((self.upper_chr_bank_bits as u16) << 8);
+                self.chr_banks[bank_index] =
+                    value as u16 | ((self.upper_chr_bank_bits as u16) << 8);
             }
-            0x5130 => {
-                // Upper CHR bank bits
-                self.upper_chr_bank_bits = value & 0x03;
-            }
+            0x5130 => self.upper_chr_bank_bits = value & 0x03,
             0x5200 => {
-                // Vertical split mode
                 self.vsplit_enabled = (value & 0x80) != 0;
                 self.vsplit_side = (value & 0x40) != 0;
                 self.vsplit_tile = value & 0x1F;
             }
-            0x5201 => {
-                // Vertical split scroll
-                self.vsplit_scroll = value;
-            }
-            0x5202 => {
-                // Vertical split bank
-                self.vsplit_bank = value;
-            }
-            0x5203 => {
-                // IRQ scanline
-                self.irq_scanline = value;
-            }
-            0x5204 => {
-                // IRQ enable
-                self.irq_enabled = (value & 0x80) != 0;
-                if self.irq_enabled && self.irq_pending {
-                    // IRQ should fire
-                }
-            }
-            0x5205 => {
-                // Multiplicand A
-                self.multiplicand_a = value;
-            }
-            0x5206 => {
-                // Multiplicand B
-                self.multiplicand_b = value;
-            }
-            0x5C00..=0x5FFF => {
-                // ExRAM write
-                if self.exram_mode < 3 {  // Mode 3 is read-only
-                    self.exram[(addr - 0x5C00) as usize] = value;
-                }
+            0x5201 => self.vsplit_scroll = value,
+            0x5202 => self.vsplit_bank = value,
+            0x5203 => self.irq_scanline = value,
+            0x5204 => self.irq_enabled = (value & 0x80) != 0,
+            0x5205 => self.multiplicand_a = value,
+            0x5206 => self.multiplicand_b = value,
+            // ExRAM mode 3 is read-only
+            0x5C00..=0x5FFF if self.exram_mode < 3 => {
+                self.exram[(addr - 0x5C00) as usize] = value;
             }
             _ => {}
         }
     }
-    
-    pub fn read_chr(&self, addr: u16) -> u8 {
-        // Handle CHR banking based on mode
-        let bank_index = match self.chr_mode {
-            0 => {
-                // 8KB mode
-                (addr / 0x2000) as usize * 8
+
+    fn read_register(&mut self, addr: u16) -> u8 {
+        match addr {
+            0x5204 => {
+                let status = ((self.irq_pending as u8) << 7) | ((self.irq_in_frame as u8) << 6);
+                self.irq_pending = false;
+                status
             }
-            1 => {
-                // 4KB mode
-                (addr / 0x1000) as usize * 4
-            }
-            2 => {
-                // 2KB mode
-                (addr / 0x800) as usize * 2
-            }
-            3 => {
-                // 1KB mode
-                (addr / 0x400) as usize
-            }
-            _ => 0
-        };
-        
-        let bank_size: usize = match self.chr_mode {
-            0 => 0x2000,
-            1 => 0x1000,
-            2 => 0x800,
-            3 => 0x400,
-            _ => 0x2000
-        };
-        
-        let bank = self.chr_banks[bank_index] as usize;
-        let offset = (bank * bank_size) + ((addr as usize) & (bank_size - 1));
-        
-        if offset < self.chr_rom.len() {
-            self.chr_rom[offset]
-        } else {
-            0
+            0x5205 => (self.get_multiplication_result() & 0xFF) as u8,
+            0x5206 => (self.get_multiplication_result() >> 8) as u8,
+            0x5C00..=0x5FFF => self.exram[(addr - 0x5C00) as usize],
+            _ => 0,
         }
     }
-    
-    pub fn read_nametable(&self, addr: u16) -> u8 {
-        // Handle special nametable modes
-        let table = ((addr - 0x2000) / 0x400) as usize;
-        match self.nametable_mapping[table] {
-            0 | 1 => {
-                // Use internal VRAM (handled by PPU)
-                0
-            }
-            2 => {
-                // Use ExRAM as nametable
-                if self.exram_mode == 0 || self.exram_mode == 1 {
-                    self.exram[(addr & 0x3FF) as usize]
-                } else {
-                    0
-                }
-            }
-            3 => {
-                // Fill mode
-                if (addr & 0x3FF) < 0x3C0 {
-                    // Tile data
-                    self.fill_mode_tile
-                } else {
-                    // Attribute data
-                    self.fill_mode_attr
-                }
-            }
-            _ => 0
-        }
-    }
-    
+
     pub fn get_multiplication_result(&self) -> u16 {
         (self.multiplicand_a as u16) * (self.multiplicand_b as u16)
     }
-    
-    pub fn clock_scanline(&mut self) {
-        if self.ppu_is_rendering {
-            if self.scanline_counter == self.irq_scanline {
-                if self.irq_enabled {
-                    self.irq_pending = true;
-                }
-            }
-            self.scanline_counter = self.scanline_counter.wrapping_add(1);
-        }
-    }
-    
+
     pub fn notify_ppu_state(&mut self, rendering: bool) {
         self.ppu_is_rendering = rendering;
         if !rendering {
@@ -368,12 +256,154 @@ impl Mapper5 {
             self.irq_in_frame = false;
         }
     }
-    
-    pub fn get_irq_pending(&self) -> bool {
+}
+
+impl Mapper for Mapper5 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        match addr {
+            0x5000..=0x5FFF => self.read_register(addr),
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xFFFF => self.read_prg(addr - 0x8000),
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x5000..=0x5FFF => self.write_register(addr, value),
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        let offset = self.chr_offset(addr);
+        self.chr.write(offset, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        // Only CIRAM sources (0 and 1) can be expressed; ExRAM (2) and fill
+        // (3) tables are approximated as CIRAM page 1.
+        let page = |t: u8| if t == 0 { 0 } else { 1 };
+        let m = [
+            page(self.nametable_mapping[0]),
+            page(self.nametable_mapping[1]),
+            page(self.nametable_mapping[2]),
+            page(self.nametable_mapping[3]),
+        ];
+        match m {
+            [0, 1, 0, 1] => Mirroring::Vertical,
+            [0, 0, 1, 1] => Mirroring::Horizontal,
+            [0, 0, 0, 0] => Mirroring::SingleScreenLower,
+            [1, 1, 1, 1] => Mirroring::SingleScreenUpper,
+            _ => Mirroring::FourScreen,
+        }
+    }
+
+    fn irq_pending(&self) -> bool {
         self.irq_pending
     }
-    
-    pub fn clear_irq(&mut self) {
+
+    fn clear_irq(&mut self) {
         self.irq_pending = false;
+    }
+
+    fn clock_scanline(&mut self) {
+        if self.ppu_is_rendering {
+            self.irq_in_frame = true;
+            if self.scanline_counter == self.irq_scanline && self.irq_enabled {
+                self.irq_pending = true;
+            }
+            self.scanline_counter = self.scanline_counter.wrapping_add(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    fn mmc5() -> Mapper5 {
+        // 16 x 8 KB PRG, 32 x 1 KB CHR
+        Mapper5::new(
+            tagged_rom(16, 0x2000),
+            tagged_rom(32, 0x400),
+            Mirroring::Vertical,
+        )
+    }
+
+    #[test]
+    fn power_on_mode_3_last_bank_everywhere() {
+        let mut m = mmc5();
+        assert_eq!(m.cpu_read(0xE000), 15);
+        m.cpu_write(0x5114, 3);
+        m.cpu_write(0x5115, 4);
+        m.cpu_write(0x5116, 5);
+        assert_eq!(m.cpu_read(0x8000), 3);
+        assert_eq!(m.cpu_read(0xA000), 4);
+        assert_eq!(m.cpu_read(0xC000), 5);
+        assert_eq!(m.cpu_read(0xE000), 15);
+    }
+
+    #[test]
+    fn prg_mode_0_uses_32k_bank() {
+        let mut m = mmc5();
+        m.cpu_write(0x5100, 0);
+        m.cpu_write(0x5117, 0x0C); // bank 3 of 32 KB
+        assert_eq!(m.cpu_read(0x8000), 12);
+        assert_eq!(m.cpu_read(0xFFFF), 15);
+    }
+
+    #[test]
+    fn chr_modes() {
+        let mut m = mmc5();
+        m.cpu_write(0x5101, 3); // 1 KB mode
+        m.cpu_write(0x5125, 9);
+        assert_eq!(m.ppu_read(0x1400), 9);
+        m.cpu_write(0x5101, 0); // 8 KB mode uses $5127
+        m.cpu_write(0x5127, 2);
+        assert_eq!(m.ppu_read(0x0000), 16);
+        assert_eq!(m.ppu_read(0x1FFF), 23);
+    }
+
+    #[test]
+    fn multiplier_and_exram() {
+        let mut m = mmc5();
+        m.cpu_write(0x5205, 200);
+        m.cpu_write(0x5206, 3);
+        assert_eq!(m.cpu_read(0x5205), 0x58);
+        assert_eq!(m.cpu_read(0x5206), 0x02);
+        m.cpu_write(0x5C10, 0xAB);
+        assert_eq!(m.cpu_read(0x5C10), 0xAB);
+    }
+
+    #[test]
+    fn nametable_mapping_to_mirroring() {
+        let mut m = mmc5();
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        m.cpu_write(0x5105, 0x50); // 0,0,1,1
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+        m.cpu_write(0x5105, 0x00);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenLower);
+    }
+
+    #[test]
+    fn scanline_irq() {
+        let mut m = mmc5();
+        m.cpu_write(0x5203, 2);
+        m.cpu_write(0x5204, 0x80);
+        m.notify_ppu_state(true);
+        m.clock_scanline();
+        m.clock_scanline();
+        assert!(!Mapper::irq_pending(&m));
+        m.clock_scanline();
+        assert!(Mapper::irq_pending(&m));
+        assert_eq!(m.cpu_read(0x5204) & 0x80, 0x80);
+        assert!(!Mapper::irq_pending(&m));
     }
 }

--- a/src/cartridge/mapper65.rs
+++ b/src/cartridge/mapper65.rs
@@ -38,6 +38,10 @@ impl Mapper65 {
 
 impl Mapper for Mapper65 {
     fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
             0x8000..=0xDFFF => {

--- a/src/cartridge/mapper65.rs
+++ b/src/cartridge/mapper65.rs
@@ -1,0 +1,121 @@
+//! Mapper 65 (Irem H3001).
+//!
+//! PRG: three switchable 8 KB banks at $8000 ($8000), $A000 ($A000) and
+//! $C000 ($C000); $E000-$FFFF fixed to the last bank.
+//! CHR: eight switchable 1 KB banks at $B000-$B007.
+//! Mirroring select ($9001) and the IRQ counter ($9003-$9006) are not
+//! implemented (they were not before this refactor either).
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper65 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+    mirroring: Mirroring,
+    prg_banks: [u8; 3],
+    chr_banks: [u8; 8],
+}
+
+impl Mapper65 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mapper65 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            mirroring,
+            prg_banks: [0, 1, 2],
+            chr_banks: [0, 1, 2, 3, 4, 5, 6, 7],
+        }
+    }
+
+    fn chr_offset(&self, addr: u16) -> usize {
+        let slot = ((addr & 0x1FFF) / 0x400) as usize;
+        self.chr_banks[slot] as usize * 0x400 + (addr & 0x3FF) as usize
+    }
+}
+
+impl Mapper for Mapper65 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xDFFF => {
+                let slot = ((addr - 0x8000) / 0x2000) as usize;
+                let offset = self.prg_banks[slot] as usize * 0x2000 + (addr & 0x1FFF) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            0xE000..=0xFFFF => {
+                let last = self.prg_rom.len().saturating_sub(0x2000);
+                prg_read(&self.prg_rom, last + (addr & 0x1FFF) as usize)
+            }
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0x8000 => self.prg_banks[0] = value,
+            0xA000 => self.prg_banks[1] = value,
+            0xC000 => self.prg_banks[2] = value,
+            0xB000..=0xB007 => self.chr_banks[(addr - 0xB000) as usize] = value,
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        let offset = self.chr_offset(addr);
+        self.chr.write(offset, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        self.mirroring
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    #[test]
+    fn prg_banks_and_fixed_last() {
+        let mut m = Mapper65::new(
+            tagged_rom(16, 0x2000),
+            tagged_rom(32, 0x400),
+            Mirroring::Vertical,
+        );
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xA000), 1);
+        assert_eq!(m.cpu_read(0xC000), 2);
+        assert_eq!(m.cpu_read(0xE000), 15);
+        m.cpu_write(0x8000, 7);
+        m.cpu_write(0xA000, 8);
+        m.cpu_write(0xC000, 9);
+        assert_eq!(m.cpu_read(0x9FFF), 7);
+        assert_eq!(m.cpu_read(0xBFFF), 8);
+        assert_eq!(m.cpu_read(0xDFFF), 9);
+        assert_eq!(m.cpu_read(0xFFFF), 15);
+    }
+
+    #[test]
+    fn chr_1k_banks() {
+        let mut m = Mapper65::new(
+            tagged_rom(4, 0x2000),
+            tagged_rom(32, 0x400),
+            Mirroring::Vertical,
+        );
+        for slot in 0..8u16 {
+            assert_eq!(m.ppu_read(slot * 0x400), slot as u8);
+        }
+        m.cpu_write(0xB003, 20);
+        assert_eq!(m.ppu_read(0x0C00), 20);
+        assert_eq!(m.ppu_read(0x0FFF), 20);
+        assert_eq!(m.ppu_read(0x1000), 4);
+    }
+}

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -1,35 +1,40 @@
+//! iNES cartridge loading and mapper construction.
+//!
+//! `Cartridge` parses the header, splits PRG/CHR, and builds a boxed
+//! `Mapper`. All bus traffic to the cartridge goes through that trait; see
+//! `mapper.rs` and docs/debugging/MAPPER_TRAIT_REFACTOR.md.
+
+pub mod mapper;
+pub mod mapper0;
+pub mod mapper1;
+pub mod mapper2;
+pub mod mapper3;
+pub mod mapper4;
+pub mod mapper5;
+pub mod mapper65;
+
 use std::fs::File;
 use std::io::{Error, ErrorKind, Read, Result};
 use std::path::Path;
 
-#[derive(Debug, Clone, Copy)]
+pub use mapper::{Mapper, NullMapper};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mirroring {
     Horizontal,
     Vertical,
     FourScreen,
-    _SingleScreenLower,
-    _SingleScreenUpper,
+    SingleScreenLower,
+    SingleScreenUpper,
 }
 
 pub struct Cartridge {
-    pub prg_rom: Vec<u8>,
-    pub chr_rom: Vec<u8>,
-    pub mapper: u8,
-    pub _mirroring: Mirroring,
-    pub _battery_backed: bool,
-    pub prg_ram: Vec<u8>,
-
-    // MMC1 state (Mapper 1)
-    mmc1_shift_register: u8,
-    mmc1_shift_count: u8,
-    mmc1_control: u8,
-    mmc1_chr_bank_0: u8,
-    mmc1_chr_bank_1: u8,
-    mmc1_prg_bank: u8,
-
-    // Mapper 65 state (Irem H3001)
-    m65_prg_banks: [u8; 3],
-    m65_chr_banks: [u8; 8],
+    /// iNES mapper number from the header.
+    pub mapper_id: u8,
+    /// Mirroring declared by the header. The live value is `mapper.mirroring()`.
+    pub header_mirroring: Mirroring,
+    pub battery_backed: bool,
+    pub mapper: Box<dyn Mapper>,
 }
 
 impl Cartridge {
@@ -67,13 +72,7 @@ impl Cartridge {
         let battery_backed = (flags_6 & 0x02) != 0;
         let trainer_present = (flags_6 & 0x04) != 0;
 
-        let mapper = (flags_7 & 0xF0) | ((flags_6 & 0xF0) >> 4);
-
-        let prg_ram_size = if data[8] == 0 {
-            0x2000
-        } else {
-            data[8] as usize * 0x2000
-        };
+        let mapper_id = (flags_7 & 0xF0) | ((flags_6 & 0xF0) >> 4);
 
         let header_size = 16;
         let trainer_size = if trainer_present { 512 } else { 0 };
@@ -85,302 +84,106 @@ impl Cartridge {
         }
 
         let prg_rom = data[prg_rom_start..prg_rom_start + prg_rom_size].to_vec();
-        let chr_rom = if chr_rom_size > 0 {
-            data[chr_rom_start..chr_rom_start + chr_rom_size].to_vec()
-        } else {
-            vec![0; 0x2000]
-        };
+        // Zero CHR banks means the board carries CHR RAM; the mapper allocates it.
+        let chr_rom = data[chr_rom_start..chr_rom_start + chr_rom_size].to_vec();
+
+        let mapper = Self::build_mapper(mapper_id, prg_rom, chr_rom, mirroring);
 
         Ok(Cartridge {
-            prg_rom,
-            chr_rom,
+            mapper_id,
+            header_mirroring: mirroring,
+            battery_backed,
             mapper,
-            _mirroring: mirroring,
-            _battery_backed: battery_backed,
-            prg_ram: vec![0; prg_ram_size],
-
-            // Initialize MMC1 state
-            mmc1_shift_register: 0,
-            mmc1_shift_count: 0,
-            mmc1_control: 0x0C, // Default: 16KB PRG mode, fixed high bank
-            mmc1_chr_bank_0: 0,
-            mmc1_chr_bank_1: 0,
-            mmc1_prg_bank: 0,
-
-            // Initialize Mapper 65 state
-            m65_prg_banks: [0, 1, 2], // Default banks
-            m65_chr_banks: [0, 1, 2, 3, 4, 5, 6, 7],
         })
     }
 
-    pub fn read_prg(&self, addr: u16) -> u8 {
-        match self.mapper {
-            0 => {
-                // Mapper 0: 16KB or 32KB PRG ROM
-                if self.prg_rom.len() == 0x4000 {
-                    // 16KB: Mirror at 0x8000-0xBFFF and 0xC000-0xFFFF
-                    self.prg_rom[(addr & 0x3FFF) as usize]
-                } else {
-                    // 32KB: Direct mapping
-                    if (addr as usize) < self.prg_rom.len() {
-                        self.prg_rom[addr as usize]
-                    } else {
-                        0xFF
-                    }
-                }
-            }
-            1 => {
-                // MMC1 Mapper
-                let prg_mode = (self.mmc1_control >> 2) & 0x03;
-                let prg_banks = self.prg_rom.len() / 0x4000;
-
-                match prg_mode {
-                    0 | 1 => {
-                        // 32KB mode: ignore low bit of bank number
-                        let bank = (self.mmc1_prg_bank & 0xFE) as usize;
-                        let offset = bank * 0x4000 + (addr as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
-                    }
-                    2 => {
-                        // Fix first bank at $8000, switch 16KB bank at $C000
-                        if addr < 0x4000 {
-                            // First bank fixed
-                            self.prg_rom[addr as usize]
-                        } else {
-                            // Switchable bank
-                            let bank = self.mmc1_prg_bank as usize;
-                            let offset = bank * 0x4000 + ((addr - 0x4000) as usize);
-                            if offset < self.prg_rom.len() {
-                                self.prg_rom[offset]
-                            } else {
-                                0
-                            }
-                        }
-                    }
-                    3 => {
-                        // Switch 16KB bank at $8000, fix last bank at $C000
-                        if addr < 0x4000 {
-                            // Switchable bank
-                            let bank = self.mmc1_prg_bank as usize;
-                            let offset = bank * 0x4000 + (addr as usize);
-                            if offset < self.prg_rom.len() {
-                                self.prg_rom[offset]
-                            } else {
-                                0
-                            }
-                        } else {
-                            // Last bank fixed
-                            let last_bank = prg_banks - 1;
-                            let offset = last_bank * 0x4000 + ((addr - 0x4000) as usize);
-                            if offset < self.prg_rom.len() {
-                                self.prg_rom[offset]
-                            } else {
-                                0
-                            }
-                        }
-                    }
-                    _ => 0,
-                }
-            }
-            65 => {
-                // Mapper 65 (Irem H3001)
-                match addr {
-                    0x0000..=0x1FFF => {
-                        // Bank 0: switchable
-                        let bank = self.m65_prg_banks[0] as usize;
-                        let offset = bank * 0x2000 + (addr as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
-                    }
-                    0x2000..=0x3FFF => {
-                        // Bank 1: switchable
-                        let bank = self.m65_prg_banks[1] as usize;
-                        let offset = bank * 0x2000 + ((addr - 0x2000) as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
-                    }
-                    0x4000..=0x5FFF => {
-                        // Bank 2: switchable
-                        let bank = self.m65_prg_banks[2] as usize;
-                        let offset = bank * 0x2000 + ((addr - 0x4000) as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
-                    }
-                    0x6000..=0x7FFF => {
-                        // Last bank: fixed to last 8KB
-                        let last_bank = (self.prg_rom.len() / 0x2000) - 1;
-                        let offset = last_bank * 0x2000 + ((addr - 0x6000) as usize);
-                        if offset < self.prg_rom.len() {
-                            self.prg_rom[offset]
-                        } else {
-                            0
-                        }
-                    }
-                    _ => 0,
-                }
-            }
-            _ => {
-                // Basic fallback for unsupported mappers
-                // Treat as 32KB ROM with simple mirroring for smaller ROMs
-                if self.prg_rom.is_empty() {
-                    return 0;
-                }
-
-                let rom_size = self.prg_rom.len();
-                if rom_size <= 0x4000 {
-                    // 16KB or smaller: mirror across the entire range
-                    self.prg_rom[(addr as usize) % rom_size]
-                } else if rom_size <= 0x8000 {
-                    // 32KB: direct mapping with bounds checking
-                    if (addr as usize) < rom_size {
-                        self.prg_rom[addr as usize]
-                    } else {
-                        // Mirror the last bank
-                        self.prg_rom[((addr as usize) % 0x4000) + rom_size - 0x4000]
-                    }
-                } else {
-                    // Larger ROMs: map the last 32KB to 0x8000-0xFFFF range
-                    // This gives the best chance of hitting the reset vector
-                    let bank_offset = rom_size - 0x8000;
-                    let mapped_addr = (addr as usize) + bank_offset;
-                    if mapped_addr < rom_size {
-                        self.prg_rom[mapped_addr]
-                    } else {
-                        0
-                    }
-                }
+    /// Construct the mapper for `mapper_id`. Unknown numbers fall back to
+    /// NROM behaviour with a warning, as before the trait existed.
+    pub fn build_mapper(
+        mapper_id: u8,
+        prg_rom: Vec<u8>,
+        chr_rom: Vec<u8>,
+        mirroring: Mirroring,
+    ) -> Box<dyn Mapper> {
+        match mapper_id {
+            0 => Box::new(mapper0::Mapper0::new(prg_rom, chr_rom, mirroring)),
+            1 => Box::new(mapper1::Mapper1::new(prg_rom, chr_rom, mirroring)),
+            2 => Box::new(mapper2::Mapper2::new(prg_rom, chr_rom, mirroring)),
+            3 => Box::new(mapper3::Mapper3::new(prg_rom, chr_rom, mirroring)),
+            4 => Box::new(mapper4::Mapper4::new(prg_rom, chr_rom, mirroring)),
+            5 => Box::new(mapper5::Mapper5::new(prg_rom, chr_rom, mirroring)),
+            65 => Box::new(mapper65::Mapper65::new(prg_rom, chr_rom, mirroring)),
+            other => {
+                log::warn!(
+                    "Unsupported mapper {}: falling back to NROM behaviour",
+                    other
+                );
+                Box::new(mapper0::Mapper0::new(prg_rom, chr_rom, mirroring))
             }
         }
     }
+}
 
-    pub fn write_prg(&mut self, addr: u16, value: u8) {
-        match self.mapper {
-            0 => {
-                log::warn!("Attempting to write to ROM at {:04X}", addr);
-            }
-            1 => {
-                // MMC1 Register writes
-                if value & 0x80 != 0 {
-                    // Reset sequence
-                    self.mmc1_shift_register = 0;
-                    self.mmc1_shift_count = 0;
-                    self.mmc1_control |= 0x0C; // Set to mode 3
-                } else {
-                    // Normal write
-                    self.mmc1_shift_register = (self.mmc1_shift_register >> 1) | ((value & 1) << 4);
-                    self.mmc1_shift_count += 1;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-                    if self.mmc1_shift_count == 5 {
-                        // Complete write
-                        match addr & 0x6000 {
-                            0x0000 => {
-                                // Control register ($8000-$9FFF)
-                                self.mmc1_control = self.mmc1_shift_register;
-                            }
-                            0x2000 => {
-                                // CHR bank 0 ($A000-$BFFF)
-                                self.mmc1_chr_bank_0 = self.mmc1_shift_register;
-                            }
-                            0x4000 => {
-                                // CHR bank 1 ($C000-$DFFF)
-                                self.mmc1_chr_bank_1 = self.mmc1_shift_register;
-                            }
-                            0x6000 => {
-                                // PRG bank ($E000-$FFFF)
-                                self.mmc1_prg_bank = self.mmc1_shift_register & 0x0F;
-                            }
-                            _ => {}
-                        }
-                        self.mmc1_shift_register = 0;
-                        self.mmc1_shift_count = 0;
-                    }
-                }
-            }
-            65 => {
-                // Mapper 65 Register writes
-                match addr {
-                    0x0000 => self.m65_prg_banks[0] = value,
-                    0x2000 => self.m65_prg_banks[1] = value,
-                    0x4000 => self.m65_prg_banks[2] = value,
-                    0x1000 => self.m65_chr_banks[0] = value,
-                    0x1001 => self.m65_chr_banks[1] = value,
-                    0x1002 => self.m65_chr_banks[2] = value,
-                    0x1003 => self.m65_chr_banks[3] = value,
-                    0x1004 => self.m65_chr_banks[4] = value,
-                    0x1005 => self.m65_chr_banks[5] = value,
-                    0x1006 => self.m65_chr_banks[6] = value,
-                    0x1007 => self.m65_chr_banks[7] = value,
-                    _ => {}
-                }
-            }
-            _ => {
-                log::warn!("Unsupported mapper: {}", self.mapper);
-            }
+    fn ines(mapper: u8, prg_banks: u8, chr_banks: u8, flags6_low: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 16];
+        data[0..4].copy_from_slice(b"NES\x1A");
+        data[4] = prg_banks;
+        data[5] = chr_banks;
+        data[6] = ((mapper & 0x0F) << 4) | flags6_low;
+        data[7] = mapper & 0xF0;
+        for bank in 0..prg_banks {
+            data.extend(vec![bank; 0x4000]);
         }
+        for bank in 0..chr_banks {
+            data.extend(vec![0x80 | bank; 0x2000]);
+        }
+        data
     }
 
-    pub fn _read_chr(&self, addr: u16) -> u8 {
-        if self.chr_rom.is_empty() {
-            return 0;
-        }
-
-        match self.mapper {
-            0 => self.chr_rom[(addr & 0x1FFF) as usize],
-            _ => {
-                log::warn!("Unsupported mapper: {}", self.mapper);
-                0
-            }
-        }
+    #[test]
+    fn parses_header_and_builds_mapper() {
+        let cart = Cartridge::load_from_bytes(&ines(3, 2, 2, 0x03)).unwrap();
+        assert_eq!(cart.mapper_id, 3);
+        assert!(cart.battery_backed);
+        assert_eq!(cart.header_mirroring, Mirroring::Vertical);
+        let mut mapper = cart.mapper;
+        assert_eq!(mapper.mirroring(), Mirroring::Vertical);
+        assert_eq!(mapper.cpu_read(0xC000), 1);
+        assert_eq!(mapper.ppu_read(0x0000), 0x80);
+        mapper.cpu_write(0x8000, 1);
+        assert_eq!(mapper.ppu_read(0x0000), 0x81);
     }
 
-    pub fn _write_chr(&mut self, addr: u16, value: u8) {
-        if self.chr_rom.is_empty() {
-            return;
-        }
-
-        match self.mapper {
-            0 => {
-                if self.chr_rom.len() == 0x2000 {
-                    self.chr_rom[(addr & 0x1FFF) as usize] = value;
-                }
-            }
-            _ => {
-                log::warn!("Unsupported mapper: {}", self.mapper);
-            }
-        }
+    #[test]
+    fn zero_chr_banks_allocates_writable_chr_ram() {
+        let cart = Cartridge::load_from_bytes(&ines(0, 1, 0, 0x00)).unwrap();
+        let mut mapper = cart.mapper;
+        assert_eq!(mapper.ppu_read(0x0100), 0);
+        mapper.ppu_write(0x0100, 0x3C);
+        assert_eq!(mapper.ppu_read(0x0100), 0x3C);
     }
 
-    pub fn _mirror_vram_addr(&self, addr: u16) -> u16 {
-        let mirrored_addr = addr & 0x2FFF;
-        let table_index = (mirrored_addr - 0x2000) / 0x0400;
+    #[test]
+    fn unknown_mapper_falls_back_to_nrom() {
+        let cart = Cartridge::load_from_bytes(&ines(200, 2, 1, 0x00)).unwrap();
+        assert_eq!(cart.mapper_id, 200);
+        let mut mapper = cart.mapper;
+        assert_eq!(mapper.cpu_read(0x8000), 0);
+        assert_eq!(mapper.cpu_read(0xC000), 1);
+    }
 
-        match self._mirroring {
-            Mirroring::Vertical => match table_index {
-                0 | 2 => 0x2000 + (mirrored_addr & 0x03FF),
-                1 | 3 => 0x2400 + (mirrored_addr & 0x03FF),
-                _ => mirrored_addr,
-            },
-            Mirroring::Horizontal => match table_index {
-                0 | 1 => 0x2000 + (mirrored_addr & 0x03FF),
-                2 | 3 => 0x2400 + (mirrored_addr & 0x03FF),
-                _ => mirrored_addr,
-            },
-            Mirroring::FourScreen => mirrored_addr,
-            Mirroring::_SingleScreenLower => 0x2000 + (mirrored_addr & 0x03FF),
-            Mirroring::_SingleScreenUpper => 0x2400 + (mirrored_addr & 0x03FF),
-        }
+    #[test]
+    fn rejects_bad_header_and_truncation() {
+        assert!(Cartridge::load_from_bytes(&[0; 8]).is_err());
+        let mut bad = ines(0, 1, 1, 0);
+        bad[0] = b'X';
+        assert!(Cartridge::load_from_bytes(&bad).is_err());
+        let mut short = ines(0, 1, 1, 0);
+        short.truncate(short.len() - 1);
+        assert!(Cartridge::load_from_bytes(&short).is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
     log::info!("Loading ROM: {}", rom_path);
 
     let cartridge = Cartridge::load_from_file(rom_path)?;
-    log::info!("ROM loaded successfully. Mapper: {}", cartridge.mapper);
+    log::info!("ROM loaded successfully. Mapper: {}", cartridge.mapper_id);
 
     let sdl_context = sdl2::init().map_err(|e| anyhow::anyhow!("SDL init failed: {}", e))?;
     let video_subsystem = sdl_context

--- a/src/ppu/mod.rs
+++ b/src/ppu/mod.rs
@@ -1,4 +1,4 @@
-use crate::cartridge::Mirroring;
+use crate::cartridge::{Mapper, Mirroring};
 use bitflags::bitflags;
 
 pub const SCREEN_WIDTH: usize = 256;
@@ -66,7 +66,9 @@ pub struct Ppu {
     pub oam_addr: u8,
     pub oam_data: [u8; 256],
     pub ppu_data_buffer: u8,
-    pub vram: [u8; 0x4000],
+    /// 4 KB of nametable RAM (2 KB CIRAM plus room for four-screen boards).
+    /// Pattern tables live in the cartridge and are read through `Mapper`.
+    pub nametable_ram: [u8; 0x1000],
     pub palette: [u8; 32],
 
     pub scanline: u16,
@@ -102,9 +104,6 @@ pub struct Ppu {
     sprite_positions: [u8; 8],
     sprite_priorities: [u8; 8],
     sprite_indexes: [u8; 8],
-
-    // Mirroring mode
-    pub mirroring: Mirroring,
 }
 
 impl Default for Ppu {
@@ -122,7 +121,7 @@ impl Ppu {
             oam_addr: 0,
             oam_data: [0; 256],
             ppu_data_buffer: 0,
-            vram: [0; 0x4000],
+            nametable_ram: [0; 0x1000],
             palette: [0; 32],
             scanline: 0,
             cycle: 0,
@@ -148,7 +147,6 @@ impl Ppu {
             sprite_positions: [0; 8],
             sprite_priorities: [0; 8],
             sprite_indexes: [0; 8],
-            mirroring: Mirroring::Horizontal,
         };
 
         // Initialize with default NES palette values
@@ -187,16 +185,16 @@ impl Ppu {
         self.nmi_interrupt = false;
     }
 
-    pub fn read_register(&mut self, address: u16) -> u8 {
+    pub fn read_register(&mut self, address: u16, mapper: &mut dyn Mapper) -> u8 {
         match address {
             0x2002 => self.read_status(),
             0x2004 => self.read_oam_data(),
-            0x2007 => self.read_ppu_data(),
+            0x2007 => self.read_ppu_data(mapper),
             _ => 0,
         }
     }
 
-    pub fn write_register(&mut self, address: u16, value: u8) {
+    pub fn write_register(&mut self, address: u16, value: u8, mapper: &mut dyn Mapper) {
         match address {
             0x2000 => self.write_ctrl(value),
             0x2001 => self.write_mask(value),
@@ -204,7 +202,7 @@ impl Ppu {
             0x2004 => self.write_oam_data(value),
             0x2005 => self.write_scroll(value),
             0x2006 => self.write_ppu_addr(value),
-            0x2007 => self.write_ppu_data(value),
+            0x2007 => self.write_ppu_data(value, mapper),
             _ => {}
         }
     }
@@ -220,15 +218,15 @@ impl Ppu {
         self.oam_data[self.oam_addr as usize]
     }
 
-    fn read_ppu_data(&mut self) -> u8 {
+    fn read_ppu_data(&mut self, mapper: &mut dyn Mapper) -> u8 {
         let addr = self.v & 0x3FFF;
         let result = if addr < 0x3F00 {
             let buffered = self.ppu_data_buffer;
-            self.ppu_data_buffer = self.read_vram(addr);
+            self.ppu_data_buffer = self.read_vram(addr, mapper);
             buffered
         } else {
-            self.ppu_data_buffer = self.read_vram(addr - 0x1000);
-            self.read_vram(addr)
+            self.ppu_data_buffer = self.read_vram(addr - 0x1000, mapper);
+            self.read_vram(addr, mapper)
         };
 
         if self.ctrl.contains(PpuCtrl::VRAM_INCREMENT) {
@@ -294,9 +292,9 @@ impl Ppu {
         self.w = !self.w;
     }
 
-    fn write_ppu_data(&mut self, value: u8) {
+    fn write_ppu_data(&mut self, value: u8, mapper: &mut dyn Mapper) {
         let addr = self.v & 0x3FFF;
-        self.write_vram(addr, value);
+        self.write_vram(addr, value, mapper);
 
         if self.ctrl.contains(PpuCtrl::VRAM_INCREMENT) {
             self.v = (self.v + 32) & 0x7FFF;
@@ -309,16 +307,16 @@ impl Ppu {
         self.oam_data.copy_from_slice(data);
     }
 
-    fn read_vram(&self, addr: u16) -> u8 {
+    fn read_vram(&mut self, addr: u16, mapper: &mut dyn Mapper) -> u8 {
         match addr {
-            0x0000..=0x1FFF => self.vram[addr as usize],
+            0x0000..=0x1FFF => mapper.ppu_read(addr),
             0x2000..=0x2FFF => {
-                let mirrored_addr = self.mirror_nametable_addr(addr);
-                self.vram[mirrored_addr as usize]
+                let index = self.mirror_nametable_addr(addr, mapper.mirroring());
+                self.nametable_ram[index as usize]
             }
             0x3000..=0x3EFF => {
                 // Mirror of 0x2000-0x2EFF
-                self.read_vram(addr - 0x1000)
+                self.read_vram(addr - 0x1000, mapper)
             }
             0x3F00..=0x3F1F => {
                 let palette_addr = (addr & 0x1F) as usize;
@@ -328,21 +326,21 @@ impl Ppu {
                     self.palette[palette_addr]
                 }
             }
-            0x3F20..=0x3FFF => self.read_vram(0x3F00 | (addr & 0x1F)),
+            0x3F20..=0x3FFF => self.read_vram(0x3F00 | (addr & 0x1F), mapper),
             _ => 0,
         }
     }
 
-    fn write_vram(&mut self, addr: u16, value: u8) {
+    fn write_vram(&mut self, addr: u16, value: u8, mapper: &mut dyn Mapper) {
         match addr {
-            0x0000..=0x1FFF => self.vram[addr as usize] = value,
+            0x0000..=0x1FFF => mapper.ppu_write(addr, value),
             0x2000..=0x2FFF => {
-                let mirrored_addr = self.mirror_nametable_addr(addr);
-                self.vram[mirrored_addr as usize] = value;
+                let index = self.mirror_nametable_addr(addr, mapper.mirroring());
+                self.nametable_ram[index as usize] = value;
             }
             0x3000..=0x3EFF => {
                 // Mirror of 0x2000-0x2EFF
-                self.write_vram(addr - 0x1000, value);
+                self.write_vram(addr - 0x1000, value, mapper);
             }
             0x3F00..=0x3F1F => {
                 let palette_addr = (addr & 0x1F) as usize;
@@ -352,16 +350,18 @@ impl Ppu {
                     self.palette[palette_addr] = value;
                 }
             }
-            0x3F20..=0x3FFF => self.write_vram(0x3F00 | (addr & 0x1F), value),
+            0x3F20..=0x3FFF => self.write_vram(0x3F00 | (addr & 0x1F), value, mapper),
             _ => {}
         }
     }
 
-    fn mirror_nametable_addr(&self, addr: u16) -> u16 {
+    /// Map a nametable address ($2000-$2FFF) to an index into `nametable_ram`
+    /// using the mirroring the mapper reports right now.
+    fn mirror_nametable_addr(&self, addr: u16, mirroring: Mirroring) -> u16 {
         let table = (addr - 0x2000) / 0x400;
         let offset = (addr - 0x2000) % 0x400;
 
-        let mirrored_table = match self.mirroring {
+        let mirrored_table = match mirroring {
             Mirroring::Horizontal => {
                 // 0,1 -> 0; 2,3 -> 1
                 match table {
@@ -382,20 +382,20 @@ impl Ppu {
                 // Each table is separate (no mirroring)
                 table & 0x03
             }
-            Mirroring::_SingleScreenLower => {
+            Mirroring::SingleScreenLower => {
                 // All tables map to table 0
                 0
             }
-            Mirroring::_SingleScreenUpper => {
+            Mirroring::SingleScreenUpper => {
                 // All tables map to table 1
                 1
             }
         };
 
-        0x2000 + mirrored_table * 0x400 + offset
+        mirrored_table * 0x400 + offset
     }
 
-    pub fn step(&mut self) {
+    pub fn step(&mut self, mapper: &mut dyn Mapper) {
         self.cycle += 1;
 
         let rendering_enabled =
@@ -419,7 +419,7 @@ impl Ppu {
 
             // Sprite fetching happens during cycles 257-320
             if self.cycle == 257 && self.mask.contains(PpuMask::SHOW_SPRITES) {
-                self.fetch_sprites();
+                self.fetch_sprites(mapper);
             }
 
             // Background rendering with cycle-accurate tile fetching
@@ -438,19 +438,19 @@ impl Ppu {
                         }
                         1 => {
                             // Fetch nametable byte (tile ID)
-                            self.fetch_nametable_byte();
+                            self.fetch_nametable_byte(mapper);
                         }
                         3 => {
                             // Fetch attribute byte (palette)
-                            self.fetch_attribute_byte();
+                            self.fetch_attribute_byte(mapper);
                         }
                         5 => {
                             // Fetch pattern table low byte
-                            self.fetch_pattern_low();
+                            self.fetch_pattern_low(mapper);
                         }
                         7 => {
                             // Fetch pattern table high byte
-                            self.fetch_pattern_high();
+                            self.fetch_pattern_high(mapper);
 
                             // Increment coarse X after fetching a complete tile
                             if self.cycle < 256 {
@@ -510,16 +510,16 @@ impl Ppu {
                             self.load_background_shifters();
                         }
                         1 => {
-                            self.fetch_nametable_byte();
+                            self.fetch_nametable_byte(mapper);
                         }
                         3 => {
-                            self.fetch_attribute_byte();
+                            self.fetch_attribute_byte(mapper);
                         }
                         5 => {
-                            self.fetch_pattern_low();
+                            self.fetch_pattern_low(mapper);
                         }
                         7 => {
-                            self.fetch_pattern_high();
+                            self.fetch_pattern_high(mapper);
                             if self.cycle < 256 {
                                 self.increment_x();
                             }
@@ -666,19 +666,19 @@ impl Ppu {
     }
 
     // Tile fetch pipeline functions
-    fn fetch_nametable_byte(&mut self) {
+    fn fetch_nametable_byte(&mut self, mapper: &mut dyn Mapper) {
         // Fetch tile ID from nametable
         // Nametable address: 0x2000 | (v & 0x0FFF)
         let addr = 0x2000 | (self.v & 0x0FFF);
-        self.bg_next_tile_id = self.read_vram(addr);
+        self.bg_next_tile_id = self.read_vram(addr, mapper);
     }
 
-    fn fetch_attribute_byte(&mut self) {
+    fn fetch_attribute_byte(&mut self, mapper: &mut dyn Mapper) {
         // Fetch attribute byte from attribute table
         // Attribute address: 0x23C0 | (v & 0x0C00) | ((v >> 4) & 0x38) | ((v >> 2) & 0x07)
         let v = self.v;
         let addr = 0x23C0 | (v & 0x0C00) | ((v >> 4) & 0x38) | ((v >> 2) & 0x07);
-        let attribute = self.read_vram(addr);
+        let attribute = self.read_vram(addr, mapper);
 
         // Determine which 2 bits of the attribute byte to use
         // based on the 2x2 tile position within the 4x4 tile group
@@ -690,7 +690,7 @@ impl Ppu {
         self.bg_next_tile_attrib = (attribute >> shift) & 0x03;
     }
 
-    fn fetch_pattern_low(&mut self) {
+    fn fetch_pattern_low(&mut self, mapper: &mut dyn Mapper) {
         // Fetch low pattern byte from pattern table
         // Pattern table address: (ctrl.bg_pattern * 0x1000) + (tile_id * 16) + fine_y
         let pattern_table = if self.ctrl.contains(PpuCtrl::BG_PATTERN) {
@@ -700,10 +700,10 @@ impl Ppu {
         };
         let fine_y = (self.v >> 12) & 0x07;
         let addr = pattern_table + (self.bg_next_tile_id as u16 * 16) + fine_y;
-        self.bg_next_tile_lsb = self.read_vram(addr);
+        self.bg_next_tile_lsb = self.read_vram(addr, mapper);
     }
 
-    fn fetch_pattern_high(&mut self) {
+    fn fetch_pattern_high(&mut self, mapper: &mut dyn Mapper) {
         // Fetch high pattern byte from pattern table
         // Pattern table address: (ctrl.bg_pattern * 0x1000) + (tile_id * 16) + fine_y + 8
         let pattern_table = if self.ctrl.contains(PpuCtrl::BG_PATTERN) {
@@ -713,7 +713,7 @@ impl Ppu {
         };
         let fine_y = (self.v >> 12) & 0x07;
         let addr = pattern_table + (self.bg_next_tile_id as u16 * 16) + fine_y + 8;
-        self.bg_next_tile_msb = self.read_vram(addr);
+        self.bg_next_tile_msb = self.read_vram(addr, mapper);
     }
 
     // Shifter update functions
@@ -841,7 +841,7 @@ impl Ppu {
         }
     }
 
-    fn fetch_sprites(&mut self) {
+    fn fetch_sprites(&mut self, mapper: &mut dyn Mapper) {
         let sprite_height = if self.ctrl.contains(PpuCtrl::SPRITE_SIZE) {
             16
         } else {
@@ -888,8 +888,8 @@ impl Ppu {
             };
 
             // Fetch pattern data
-            let low_byte = self.vram[(pattern_addr & 0x1FFF) as usize];
-            let high_byte = self.vram[((pattern_addr + 8) & 0x1FFF) as usize];
+            let low_byte = mapper.ppu_read(pattern_addr & 0x1FFF);
+            let high_byte = mapper.ppu_read((pattern_addr + 8) & 0x1FFF);
 
             // Handle horizontal flip
             let (low, high) = if (attributes & 0x40) != 0 {
@@ -1013,3 +1013,105 @@ const NES_PALETTE: [(u8, u8, u8); 64] = [
     (0x11, 0x11, 0x11),
     (0x11, 0x11, 0x11),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cartridge::mapper3::Mapper3;
+    use crate::cartridge::mapper4::Mapper4;
+    use crate::cartridge::Cartridge;
+
+    fn tagged_chr(banks: usize) -> Vec<u8> {
+        let mut chr = Vec::new();
+        for bank in 0..banks {
+            chr.extend(vec![0x10 + bank as u8; 0x2000]);
+        }
+        chr
+    }
+
+    /// Set the VRAM address through $2006 and read $2007 twice (the first
+    /// read only fills the buffer for addresses below the palette).
+    fn read_ppu_addr(ppu: &mut Ppu, mapper: &mut dyn Mapper, addr: u16) -> u8 {
+        ppu.write_register(0x2006, (addr >> 8) as u8, mapper);
+        ppu.write_register(0x2006, addr as u8, mapper);
+        ppu.read_register(0x2007, mapper);
+        ppu.read_register(0x2007, mapper)
+    }
+
+    fn write_ppu_addr(ppu: &mut Ppu, mapper: &mut dyn Mapper, addr: u16, value: u8) {
+        ppu.write_register(0x2006, (addr >> 8) as u8, mapper);
+        ppu.write_register(0x2006, addr as u8, mapper);
+        ppu.write_register(0x2007, value, mapper);
+    }
+
+    #[test]
+    fn pattern_table_reads_follow_chr_bank_switch() {
+        let mut ppu = Ppu::new();
+        let mut mapper = Mapper3::new(vec![0; 0x8000], tagged_chr(2), Mirroring::Vertical);
+
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x0000), 0x10);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x1FFF), 0x10);
+
+        mapper.cpu_write(0x8000, 1);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x0000), 0x11);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x1FFF), 0x11);
+    }
+
+    #[test]
+    fn chr_ram_writes_go_through_the_mapper() {
+        let mut ppu = Ppu::new();
+        let cart = Cartridge::build_mapper(0, vec![0; 0x8000], vec![], Mirroring::Vertical);
+        let mut mapper = cart;
+
+        write_ppu_addr(&mut ppu, mapper.as_mut(), 0x0123, 0xA5);
+        assert_eq!(mapper.ppu_read(0x0123), 0xA5);
+        assert_eq!(read_ppu_addr(&mut ppu, mapper.as_mut(), 0x0123), 0xA5);
+    }
+
+    #[test]
+    fn background_fetch_uses_mapper_pattern_bytes() {
+        let mut ppu = Ppu::new();
+        let mut mapper = Mapper3::new(vec![0; 0x8000], tagged_chr(2), Mirroring::Vertical);
+        ppu.bg_next_tile_id = 0x05;
+        ppu.v = 0;
+
+        ppu.fetch_pattern_low(&mut mapper);
+        ppu.fetch_pattern_high(&mut mapper);
+        assert_eq!((ppu.bg_next_tile_lsb, ppu.bg_next_tile_msb), (0x10, 0x10));
+
+        mapper.cpu_write(0x8000, 1);
+        ppu.fetch_pattern_low(&mut mapper);
+        ppu.fetch_pattern_high(&mut mapper);
+        assert_eq!((ppu.bg_next_tile_lsb, ppu.bg_next_tile_msb), (0x11, 0x11));
+    }
+
+    #[test]
+    fn nametable_mirroring_is_queried_per_access() {
+        let mut ppu = Ppu::new();
+        let mut mapper = Mapper4::new(vec![0; 0x8000], tagged_chr(1), Mirroring::Vertical);
+
+        // Vertical: $2000 and $2800 share a table; $2400 is separate
+        write_ppu_addr(&mut ppu, &mut mapper, 0x2000, 0x11);
+        write_ppu_addr(&mut ppu, &mut mapper, 0x2400, 0x22);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x2800), 0x11);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x2C00), 0x22);
+
+        // Switch the MMC3 to horizontal: $2000 and $2400 now share a table
+        mapper.cpu_write(0xA000, 1);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x2400), 0x11);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x2800), 0x22);
+    }
+
+    #[test]
+    fn mirror_nametable_addr_modes() {
+        let ppu = Ppu::new();
+        let a = |m: Mirroring, addr: u16| ppu.mirror_nametable_addr(addr, m);
+        assert_eq!(a(Mirroring::Horizontal, 0x2400), 0x000);
+        assert_eq!(a(Mirroring::Horizontal, 0x2800), 0x400);
+        assert_eq!(a(Mirroring::Vertical, 0x2400), 0x400);
+        assert_eq!(a(Mirroring::Vertical, 0x2800), 0x000);
+        assert_eq!(a(Mirroring::SingleScreenLower, 0x2C05), 0x005);
+        assert_eq!(a(Mirroring::SingleScreenUpper, 0x2005), 0x405);
+        assert_eq!(a(Mirroring::FourScreen, 0x2C00), 0xC00);
+    }
+}

--- a/src/system.rs
+++ b/src/system.rs
@@ -2704,16 +2704,8 @@ impl System {
     pub fn peek(&self, addr: u16) -> u8 {
         match addr {
             0x0000..=0x1FFF => self.cpu_ram[(addr & 0x07FF) as usize],
-            0x6000..=0x7FFF => match self.cartridge {
-                Some(ref cart) => cart
-                    .prg_ram
-                    .get((addr - 0x6000) as usize)
-                    .copied()
-                    .unwrap_or(0),
-                None => 0,
-            },
-            0x8000..=0xFFFF => match self.cartridge {
-                Some(ref cart) => cart.read_prg(addr - 0x8000),
+            0x6000..=0xFFFF => match self.cartridge {
+                Some(ref cart) => cart.mapper.cpu_peek(addr),
                 None => 0,
             },
             _ => 0,
@@ -2734,9 +2726,7 @@ impl System {
             0x0000..=0x1FFF => self.cpu_ram[(addr & 0x07FF) as usize] = value,
             0x6000..=0x7FFF => {
                 if let Some(ref mut cart) = self.cartridge {
-                    if let Some(slot) = cart.prg_ram.get_mut((addr - 0x6000) as usize) {
-                        *slot = value;
-                    }
+                    cart.mapper.cpu_write(addr, value);
                 }
             }
             _ => {}

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,5 +1,5 @@
 use crate::apu::Apu;
-use crate::cartridge::Cartridge;
+use crate::cartridge::{Cartridge, Mapper, NullMapper};
 use crate::input::Controller;
 use crate::ppu::Ppu;
 use std::collections::VecDeque;
@@ -24,6 +24,8 @@ pub struct System {
     pub controller1: Controller,
     pub controller2: Controller,
     pub cartridge: Option<Cartridge>,
+    /// Stand-in mapper handed to the PPU while no cartridge is loaded.
+    null_mapper: NullMapper,
     cycles: u64,
     oam_dma_cycles: u16,
     audio_sample_counter: f64,
@@ -61,6 +63,7 @@ impl System {
             controller1: Controller::new(),
             controller2: Controller::new(),
             cartridge: None,
+            null_mapper: NullMapper,
             cycles: 0,
             oam_dma_cycles: 0,
             audio_sample_counter: 0.0,
@@ -87,9 +90,9 @@ impl System {
         log::info!("Reset CPU, PC set to: 0x{:04X}", self.cpu_pc);
 
         // Log first few bytes at reset vector for debugging
-        if let Some(ref cart) = self.cartridge {
-            let vec_lo = cart.read_prg(0x7FFC);
-            let vec_hi = cart.read_prg(0x7FFD);
+        if let Some(ref mut cart) = self.cartridge {
+            let vec_lo = cart.mapper.cpu_read(0xFFFC);
+            let vec_hi = cart.mapper.cpu_read(0xFFFD);
             log::info!(
                 "Reset vector bytes: 0x{:02X} 0x{:02X} => PC: 0x{:04X}",
                 vec_lo,
@@ -100,29 +103,28 @@ impl System {
     }
 
     pub fn load_cartridge(&mut self, cartridge: Cartridge) {
-        // Set mirroring mode from cartridge
-        self.ppu.mirroring = cartridge._mirroring;
-
-        // Copy CHR ROM to PPU VRAM pattern tables if CHR ROM exists
-        if !cartridge.chr_rom.is_empty() {
-            for i in 0..cartridge.chr_rom.len().min(0x2000) {
-                self.ppu.vram[i] = cartridge.chr_rom[i];
-            }
-        } else {
-            // CHR RAM: Initialize pattern tables to zero (will be written by game)
-            for i in 0..0x2000 {
-                self.ppu.vram[i] = 0;
-            }
-        }
-
+        // Pattern tables and mirroring are served by the cartridge mapper on
+        // every PPU access, so nothing is copied into the PPU here.
         self.cartridge = Some(cartridge);
         self.reset();
+    }
+
+    /// Split borrow: the PPU and the mapper it should talk to for this access.
+    fn ppu_and_mapper(&mut self) -> (&mut Ppu, &mut dyn Mapper) {
+        let mapper: &mut dyn Mapper = match self.cartridge.as_mut() {
+            Some(cart) => cart.mapper.as_mut(),
+            None => &mut self.null_mapper,
+        };
+        (&mut self.ppu, mapper)
     }
 
     fn read_byte(&mut self, addr: u16) -> u8 {
         match addr {
             0x0000..=0x1FFF => self.cpu_ram[(addr & 0x07FF) as usize],
-            0x2000..=0x3FFF => self.ppu.read_register(0x2000 | (addr & 0x0007)),
+            0x2000..=0x3FFF => {
+                let (ppu, mapper) = self.ppu_and_mapper();
+                ppu.read_register(0x2000 | (addr & 0x0007), mapper)
+            }
             0x4000..=0x4015 => self.apu.read_register(addr),
             0x4016 => {
                 let value = self.controller1.read();
@@ -133,20 +135,10 @@ impl System {
                 // Controller 2 not connected, return 0
                 0x00
             }
-            0x6000..=0x7FFF => {
-                if let Some(ref cart) = self.cartridge {
-                    cart.prg_ram[(addr - 0x6000) as usize]
-                } else {
-                    0
-                }
-            }
-            0x8000..=0xFFFF => {
-                if let Some(ref cart) = self.cartridge {
-                    cart.read_prg(addr - 0x8000)
-                } else {
-                    0
-                }
-            }
+            0x4020..=0xFFFF => match self.cartridge {
+                Some(ref mut cart) => cart.mapper.cpu_read(addr),
+                None => 0,
+            },
             _ => 0,
         }
     }
@@ -154,7 +146,10 @@ impl System {
     fn write_byte(&mut self, addr: u16, value: u8) {
         match addr {
             0x0000..=0x1FFF => self.cpu_ram[(addr & 0x07FF) as usize] = value,
-            0x2000..=0x3FFF => self.ppu.write_register(0x2000 | (addr & 0x0007), value),
+            0x2000..=0x3FFF => {
+                let (ppu, mapper) = self.ppu_and_mapper();
+                ppu.write_register(0x2000 | (addr & 0x0007), value, mapper)
+            }
             0x4000..=0x4013 | 0x4015 => self.apu.write_register(addr, value),
             0x4014 => {
                 // OAM DMA - Direct Memory Access to PPU OAM
@@ -176,14 +171,9 @@ impl System {
                 // Controller 2 strobe is handled but we don't have a second controller
             }
             0x4017 => self.apu.write_register(addr, value),
-            0x6000..=0x7FFF => {
+            0x4020..=0xFFFF => {
                 if let Some(ref mut cart) = self.cartridge {
-                    cart.prg_ram[(addr - 0x6000) as usize] = value;
-                }
-            }
-            0x8000..=0xFFFF => {
-                if let Some(ref mut cart) = self.cartridge {
-                    cart.write_prg(addr - 0x8000, value);
+                    cart.mapper.cpu_write(addr, value);
                 }
             }
             _ => {}
@@ -2641,7 +2631,8 @@ impl System {
     }
 
     fn ppu_step(&mut self) {
-        self.ppu.step();
+        let (ppu, mapper) = self.ppu_and_mapper();
+        ppu.step(mapper);
     }
 
     /// Poll the interrupt inputs at an instruction boundary and service one

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -35,12 +35,12 @@ pub fn load_rom(rel: &str) -> System {
 /// tile indices, so the on-screen console can be read back verbatim.
 /// Non-printable tiles become spaces; trailing blank lines are dropped.
 pub fn screen_text(system: &System) -> String {
-    let vram = &system.ppu.vram;
+    let nametable = &system.ppu.nametable_ram;
     let mut lines: Vec<String> = Vec::new();
     for row in 0..30 {
         let mut line = String::with_capacity(32);
         for col in 0..32 {
-            let tile = vram[0x2000 + row * 32 + col];
+            let tile = nametable[row * 32 + col];
             let ch = if (0x20..0x7F).contains(&tile) {
                 tile as char
             } else {


### PR DESCRIPTION
Closes #2 (Phase 2 of docs/plans/ACCURACY_ROADMAP.md).

## What changed

- New `Mapper` trait in `src/cartridge/mapper.rs`: `cpu_read`, `cpu_write`, `ppu_read`, `ppu_write`, `mirroring`, `irq_pending`, `clear_irq`, `clock_scanline` (last three default to no-op). Boxed, `Send`, no generics.
- One file per mapper: `mapper0` (NROM, also the unknown-mapper fallback with a warning logged once at load), `mapper1` (MMC1), `mapper2` (UxROM, new), `mapper3` (CNROM, new), `mapper4` (MMC3, the previously dead file, now wired and converted to absolute CPU addresses), `mapper5` (MMC5, wired for the first time), `mapper65` (moved out of `mod.rs`).
- `Cartridge` parses iNES and builds the boxed mapper; CHR RAM is allocated as 8 KB inside the mapper when the header has zero CHR banks and is writable through `ppu_write`. PRG RAM now lives in each mapper too.
- The load-time CHR copy is gone. `Ppu::step`, `read_register` and `write_register` take `&mut dyn Mapper`; every pattern-table access ($0000-$1FFF) goes through the mapper, and `mirror_nametable_addr` asks the mapper for mirroring on each access. `Ppu::vram` (16 KB) became `Ppu::nametable_ram` (4 KB).
- `System::read_byte` / `write_byte` route $4020-$FFFF to `cpu_read` / `cpu_write`. Only the cartridge and PPU call sites in `system.rs` were touched; the CPU opcode match and interrupt path are untouched.
- MMC3 `clock_scanline` is the existing counter byte-for-byte and is exposed through `irq_pending()`; nothing clocks it or delivers the IRQ yet (follow-up lane #3).
- Docs: `docs/debugging/MAPPER_TRAIT_REFACTOR.md` covers the trait, the wiring choice, per-mapper notes, before/after frame results, how to add a mapper, and an appendix with the frame-diff harness.

### Behaviour changes beyond CHR routing (deliberate, called out)

- Mapper 65 CHR bank registers moved from $9000-$9007 to $B000-$B007 to match the Irem H3001 layout. The old offset never mattered because CHR never reached the PPU.
- Out-of-range PRG bank reads wrap to the ROM size instead of returning 0 (what the address lines do; the MMC3 code already did this).
- MMC3 $E000-$FFFF reads now work (the dead file returned 0). MMC3 PRG RAM defaults to enabled, matching the old System behaviour of always serving $6000-$7FFF; $A001 bit 7 disables it, bit 6 write-protects.
- MMC1 mirroring now follows the control register per write instead of the header only.

## Verified headlessly

- `cargo build`, `cargo test` (48 tests), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all pass.
- Mapper unit tests with synthetic bank-tagged ROMs: MMC1 shift register, reset bit, PRG modes 0-3, CHR 4 KB and 8 KB modes, mirroring; MMC3 bank registers in both PRG and CHR modes, PRG RAM protect, mirroring, scanline counter reload/decrement/pending/acknowledge; NROM, UxROM, CNROM, H3001 and MMC5 bank arithmetic.
- iNES parsing: mapper number, battery flag, CHR RAM allocation, unknown-mapper fallback, header and truncation errors.
- PPU-level tests proving the wiring rather than just the arithmetic: a $2007 pattern read follows a CNROM bank switch; a $2007 write reaches the mapper's CHR RAM; `fetch_pattern_low/high` read the mapper; an MMC3 $A000 write changes nametable mirroring for the very next access.
- Frame diff: a scratch harness (source in the doc appendix) ran each ROM for several hundred frames on a build of `main` and on this branch and compared the raw RGB buffers.

| ROM | Board | main | this branch |
|-----|-------|------|-------------|
| TMNT | MMC3, CHR ROM | multicoloured garbage where the logo should be | correct title screen; correct overworld tiles and sprites after Start |
| Contra | UxROM, CHR RAM | blank blue | correct title screen (mapper 2 previously hit the fallback) |
| SMB3 | MMC3, CHR ROM | blank blue | opening curtain renders in the top half; bottom half black, consistent with the unwired MMC3 scanline IRQ, re-check after #3 |
| mario.nes | NROM | title screen | byte-identical |
| Final Fantasy | MMC1, CHR RAM | intro text | byte-identical |
| Zelda | MMC1, CHR RAM | blank blue at 900 frames | byte-identical |

## Needs a human visual pass

Run the SDL binary and check:

- SMB: use `roms/mario.nes`. `roms/SuperMarioBros.nes` has a dirty iNES header (reads as mapper 66) and is black on both main and this branch. Expect the title screen unchanged.
- TMNT (MMC3): the Ultra Games / TMNT logo and PUSH START text should be intact where they were garbage before; in-game overworld tiles, the status box and the turtle sprite should be correct after pressing Start.
- SMB3 (MMC3): the red opening curtain should render across the top of the screen where the whole screen was blank before. The lower half will stay black until the MMC3 IRQ lane (#3) lands; do not treat that as a regression here.
- Zelda (MMC1): expected unchanged. Rendering is enabled ($2001 = 0x1E) but the palette is never written, so the game has not reached its PPU init; that is a CPU-side or NMI-path symptom for another lane, not CHR.
