### PR TITLE
fix(ppu): mask OAM attribute bits and model 2004 access during rendering

### DIFF
--- a/docs/debugging/PPU_CYCLE_ACCURATE_REFACTOR.md
+++ b/docs/debugging/PPU_CYCLE_ACCURATE_REFACTOR.md
@@ -626,3 +626,53 @@ cargo build --bin nes-emu
 **Final Build:** ✅ No errors, 2 harmless warnings
 
 **Game Compatibility:** Ready for testing with Super Mario Bros, Zelda, Metroid, and other scrolling games
+
+---
+
+## OAM READ/WRITE BEHAVIOUR (Issue 14)
+
+**Date:** 2026-09-05
+**Discovered:** blargg oam_stress reported every fourth OAM byte reading back wrong
+
+### Symptom
+
+oam_stress printed a 16x16 grid with a `*` in every column 2, 6, 10 and 14
+(the attribute byte of each 4-byte sprite entry) and failed with code
+59916E5B. oam_read passed because it only checks that reads follow OAMADDR.
+
+### Root Cause
+
+Bits 2-4 of each sprite's attribute byte do not exist in the PPU's OAM
+memory. Hardware always reads them back as 0, but `write_oam_data` stored
+the full byte, so a write of $FF read back as $FF instead of $E3.
+
+### Fix (`src/ppu/mod.rs`)
+
+1. **Attribute masking:** `mask_oam_byte` drops bits 2-4 on offset 2 of each
+   sprite before storing. OAM DMA funnels through `$2004` so it is covered
+   too; the unused `_oam_dma` helper masks as well for consistency.
+2. **`$2004` reads during rendering:** with background or sprites enabled on
+   a visible or pre-render line, cycles 1-64 return $FF because the sprite
+   evaluation unit is clearing secondary OAM. Outside that window the read
+   returns `oam_data[oam_addr]`. This is an approximation: hardware returns
+   the byte the evaluation unit is examining, which needs the per-cycle
+   sprite evaluation from issue 11.
+3. **`$2004` writes during rendering:** the data is ignored but OAMADDR still
+   performs the glitchy increment (bits 2-7 advance by one sprite, bits 0-1
+   unchanged). Outside rendering the write stores and increments by one.
+4. **`$2003` writes** set OAMADDR; the rendering-time corruption is out of
+   scope.
+
+Covered by five unit tests in the PPU tests module (`oam_*`).
+
+### Results
+
+- oam_stress: **Passed** (un-ignored in `tests/blargg.rs`, about 7 s in debug)
+- oam_read: still passes
+- Full suite and nestest: no regressions (35 blargg pass, 41 ignored)
+
+### Remaining Limitation
+
+Known Limitations item 3 (batched sprite evaluation) still applies. Until it
+is replaced, `$2004` reads between cycles 65 and 340 of a rendering line do
+not track the evaluation pointer.

--- a/docs/testing/TEST_ROM_HARNESS.md
+++ b/docs/testing/TEST_ROM_HARNESS.md
@@ -137,11 +137,11 @@ arms, so the unimplemented-opcode fallback was removed.
 | apu_test (8 + 1) | 5 | 4 | 2, 3, 4, 7, 8 pass since the IRQ line landed (Phase 3); 1 #4, 5 #3, 6 #2 remain; combined fails in test 1 |
 | apu_reset (6) | 1 | 5 | 4015_cleared #2, 4017_timing #3, 4017_written #2, len_ctrs_enabled #3, works_immediately #2; irq_flag_cleared passes |
 | oam_read | 1 | 0 | |
-| oam_stress | 0 | 1 | every 4th OAM byte reads back wrong |
+| oam_stress | 1 | 0 | passes since attribute bits 2-4 are masked (issue 14) |
 | mmc3_test_2 (6) | 4 | 2 | 4 needs cycle-exact sprite fetch positions (Phase 5); 6 is the alternate revision, exclusive with 5 |
-| **Total blargg** | **34** | **42** | |
+| **Total blargg** | **35** | **41** | |
 
-Combined with nestest: 20 tests pass, 62 are ignored.
+Combined with nestest: 42 tests pass, 41 are ignored.
 
 ### Expected progression
 
@@ -150,7 +150,7 @@ Combined with nestest: 20 tests pass, 62 are ignored.
 | CPU fix for `$B4` (small, can ride with any phase) | instr_test-v5 05/official_only/all_instrs, nestest full register compare, likely `cpu_timing_test6` moves to a timing failure |
 | Phase 3 (IRQ line, NMI edge) | cpu_interrupts_v2, apu_reset (landed: apu_test 2/3/4/7/8 and mmc3_test_2 1/2/3/5 pass) |
 | Phase 4 (bus-tick timing) | landed: ppu_vbl_nmi 01/03 and sprite_hit 11 now pass |
-| Phase 5 (PPU cycle detail) | sprite_hit_tests, sprite_overflow_tests, ppu_open_bus, oam_stress, mmc3_test_2 4, ppu_vbl_nmi 02/04-10, apu_test 1/5/6 |
+| Phase 5 (PPU cycle detail) | sprite_hit_tests, sprite_overflow_tests, ppu_open_bus, mmc3_test_2 4, ppu_vbl_nmi 02/04-10, apu_test 1/5/6 (landed: oam_stress via issue 14) |
 | Interrupt sampling (follow-up issue) | cpu_interrupts_v2 |
 
 ## Debug API reference (`src/system.rs`)

--- a/src/ppu/mod.rs
+++ b/src/ppu/mod.rs
@@ -227,7 +227,18 @@ impl Ppu {
         result
     }
 
+    /// $2004 read. Never modifies OAMADDR.
+    ///
+    /// While rendering is active the PPU's sprite evaluation unit owns the
+    /// OAM bus, so the CPU sees whatever byte it is examining. During the
+    /// secondary OAM clear (cycles 1-64) that is always $FF. For the rest of
+    /// the line we return `oam_data[oam_addr]`; this is an approximation
+    /// until per-cycle sprite evaluation lands (issue 11), at which point the
+    /// read should follow the evaluation unit's own OAM pointer.
     fn read_oam_data(&self) -> u8 {
+        if self.is_rendering() && (1..=64).contains(&self.cycle) {
+            return 0xFF;
+        }
         self.oam_data[self.oam_addr as usize]
     }
 
@@ -270,13 +281,48 @@ impl Ppu {
         self.mask = PpuMask::from_bits_truncate(value);
     }
 
+    /// $2003 write. The OAMADDR corruption that a write during rendering
+    /// causes on hardware is intentionally not modelled here.
     fn write_oam_addr(&mut self, value: u8) {
         self.oam_addr = value;
     }
 
+    /// $2004 write.
+    ///
+    /// Outside rendering the byte is stored at OAMADDR and OAMADDR advances by
+    /// one. Bits 2-4 of every sprite's attribute byte (offset 2 of each
+    /// 4-byte entry) do not physically exist, so they are dropped on write and
+    /// always read back as 0. OAM DMA funnels through this path too.
+    ///
+    /// During rendering the data is ignored, but OAMADDR still performs the
+    /// glitchy increment documented on nesdev: bits 2-7 advance by one sprite
+    /// (4 bytes) while bits 0-1 are left untouched.
     fn write_oam_data(&mut self, value: u8) {
-        self.oam_data[self.oam_addr as usize] = value;
+        if self.is_rendering() {
+            let high = (self.oam_addr & 0xFC).wrapping_add(4);
+            self.oam_addr = high | (self.oam_addr & 0x03);
+            return;
+        }
+        self.oam_data[self.oam_addr as usize] = Self::mask_oam_byte(self.oam_addr, value);
         self.oam_addr = self.oam_addr.wrapping_add(1);
+    }
+
+    /// Drop the unimplemented bits 2-4 of attribute bytes; other bytes pass
+    /// through unchanged.
+    fn mask_oam_byte(addr: u8, value: u8) -> u8 {
+        if addr & 0x03 == 2 {
+            value & 0xE3
+        } else {
+            value
+        }
+    }
+
+    /// True while the PPU is actively rendering: background or sprites are
+    /// enabled and the current line is visible or the pre-render line.
+    fn is_rendering(&self) -> bool {
+        let enabled =
+            self.mask.contains(PpuMask::SHOW_BG) || self.mask.contains(PpuMask::SHOW_SPRITES);
+        enabled && (self.scanline < 240 || self.scanline == 261)
     }
 
     fn write_scroll(&mut self, value: u8) {
@@ -320,7 +366,9 @@ impl Ppu {
     }
 
     pub fn _oam_dma(&mut self, data: &[u8; 256]) {
-        self.oam_data.copy_from_slice(data);
+        for (i, (dst, src)) in self.oam_data.iter_mut().zip(data).enumerate() {
+            *dst = Self::mask_oam_byte(i as u8, *src);
+        }
     }
 
     /// Record a new value on the PPU address bus and report a filtered A12
@@ -1179,5 +1227,102 @@ mod tests {
         assert_eq!(a(Mirroring::SingleScreenLower, 0x2C05), 0x005);
         assert_eq!(a(Mirroring::SingleScreenUpper, 0x2005), 0x405);
         assert_eq!(a(Mirroring::FourScreen, 0x2C00), 0xC00);
+    }
+
+    // -----------------------------------------------------------------
+    // OAM ($2003/$2004) behaviour, issue 14
+    // -----------------------------------------------------------------
+
+    fn oam_ppu(scanline: u16, cycle: u16, mask: PpuMask) -> Ppu {
+        let mut ppu = Ppu::new();
+        ppu.scanline = scanline;
+        ppu.cycle = cycle;
+        ppu.mask = mask;
+        ppu
+    }
+
+    fn oam_write(ppu: &mut Ppu, addr: u8, value: u8) {
+        let mut mapper = Mapper3::new(vec![0; 0x8000], tagged_chr(1), Mirroring::Vertical);
+        ppu.write_register(0x2003, addr, &mut mapper);
+        ppu.write_register(0x2004, value, &mut mapper);
+    }
+
+    fn oam_read(ppu: &mut Ppu, addr: u8) -> u8 {
+        let mut mapper = Mapper3::new(vec![0; 0x8000], tagged_chr(1), Mirroring::Vertical);
+        ppu.write_register(0x2003, addr, &mut mapper);
+        ppu.read_register(0x2004, &mut mapper)
+    }
+
+    #[test]
+    fn oam_attribute_bytes_drop_bits_2_to_4() {
+        let mut ppu = oam_ppu(241, 10, PpuMask::empty());
+        for addr in 0u8..8 {
+            oam_write(&mut ppu, addr, 0xFF);
+        }
+        for addr in 0u8..8 {
+            let expected = if addr & 3 == 2 { 0xE3 } else { 0xFF };
+            assert_eq!(oam_read(&mut ppu, addr), expected, "OAM[{addr}]");
+        }
+    }
+
+    #[test]
+    fn oam_write_in_vblank_stores_and_increments_by_one() {
+        let mut ppu = oam_ppu(241, 10, PpuMask::SHOW_BG | PpuMask::SHOW_SPRITES);
+        oam_write(&mut ppu, 0x13, 0x42);
+        assert_eq!(ppu.oam_addr, 0x14);
+        assert_eq!(oam_read(&mut ppu, 0x13), 0x42);
+        assert_eq!(ppu.oam_addr, 0x13, "reads do not move OAMADDR");
+    }
+
+    #[test]
+    fn oam_write_with_rendering_disabled_is_normal_on_visible_line() {
+        let mut ppu = oam_ppu(100, 30, PpuMask::empty());
+        oam_write(&mut ppu, 0x20, 0x99);
+        assert_eq!(ppu.oam_addr, 0x21);
+        assert_eq!(oam_read(&mut ppu, 0x20), 0x99);
+    }
+
+    #[test]
+    fn oam_read_returns_ff_during_secondary_oam_clear() {
+        let mut ppu = oam_ppu(241, 10, PpuMask::empty());
+        oam_write(&mut ppu, 0x05, 0x37);
+        ppu.mask = PpuMask::SHOW_SPRITES;
+
+        for (scanline, cycle) in [(0, 1), (100, 32), (239, 64), (261, 10)] {
+            ppu.scanline = scanline;
+            ppu.cycle = cycle;
+            assert_eq!(
+                oam_read(&mut ppu, 0x05),
+                0xFF,
+                "line {scanline} cycle {cycle}"
+            );
+        }
+
+        ppu.scanline = 100;
+        ppu.cycle = 65;
+        assert_eq!(oam_read(&mut ppu, 0x05), 0x37, "after the clear window");
+        ppu.cycle = 0;
+        assert_eq!(oam_read(&mut ppu, 0x05), 0x37, "idle cycle 0");
+        ppu.scanline = 241;
+        ppu.cycle = 32;
+        assert_eq!(oam_read(&mut ppu, 0x05), 0x37, "vblank");
+    }
+
+    #[test]
+    fn oam_write_during_rendering_is_ignored_with_glitchy_increment() {
+        let mut ppu = oam_ppu(241, 10, PpuMask::empty());
+        oam_write(&mut ppu, 0x07, 0x11);
+        ppu.mask = PpuMask::SHOW_BG;
+        ppu.scanline = 50;
+        ppu.cycle = 200;
+
+        oam_write(&mut ppu, 0x07, 0xEE);
+        assert_eq!(ppu.oam_addr, 0x0B, "bits 2-7 advance by one sprite");
+        ppu.oam_addr = 0xFE;
+        oam_write(&mut ppu, 0xFE, 0xEE);
+        assert_eq!(ppu.oam_addr, 0x02, "wraps without touching bits 0-1");
+
+        ppu.mask = PpuMask::empty();
+        assert_eq!(oam_read(&mut ppu, 0x07), 0x11, "data was not stored");
     }
 }

--- a/tests/blargg.rs
+++ b/tests/blargg.rs
@@ -492,12 +492,7 @@ blargg_test!(
 // OAM
 // ---------------------------------------------------------------------
 blargg_test!(oam_read, "oam_read/oam_read.nes", SHORT);
-blargg_test!(
-    oam_stress,
-    "oam_stress/oam_stress.nes",
-    LONG,
-    ignore = "fails, OAM readback pattern shows every 4th byte wrong; Phase 5"
-);
+blargg_test!(oam_stress, "oam_stress/oam_stress.nes", LONG);
 
 // ---------------------------------------------------------------------
 // mmc3_test_2: MMC3 IRQ counter and A12 clocking


### PR DESCRIPTION
Closes #14

## What changed (src/ppu/mod.rs)

- **Attribute masking:** bits 2-4 of offset 2 in every 4-byte sprite entry are dropped on write (`mask_oam_byte`), so they read back as 0. OAM DMA funnels through `$2004` so it is covered; the unused `_oam_dma` helper masks too.
- **`$2004` reads during rendering** (BG or sprites enabled, visible or pre-render line): cycles 1-64 return `$FF` (secondary OAM clear). Outside that window the read returns `oam_data[oam_addr]`, documented as an approximation until per-cycle sprite evaluation (#11) exists.
- **`$2004` writes during rendering:** data ignored, OAMADDR does the glitchy increment (bits 2-7 advance by 4, bits 0-1 unchanged). Outside rendering: normal store and increment by 1.
- **`$2003` writes:** unchanged; rendering-time OAMADDR corruption is out of scope.
- Five new unit tests in the PPU tests module (`oam_*`).
- `oam_stress` un-ignored in `tests/blargg.rs`.
- Docs: `docs/testing/TEST_ROM_HARNESS.md` row and totals updated; new section in `docs/debugging/PPU_CYCLE_ACCURATE_REFACTOR.md`.

No changes to `src/system.rs` or `src/cartridge/*`; no new dependencies.

## Verified headlessly (debug build)

- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`: clean
- `cargo test`: lib 70 passed; blargg 35 passed / 41 ignored (was 34 / 42); nestest 7 passed
- `oam_stress`: **Passed** (was failing with every 4th byte wrong, code 59916E5B); ~7 s
- `oam_read`: still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
