### PR TITLE
feat(cpu): sample interrupts on the penultimate cycle of each instruction

### DIFF
--- a/docs/debugging/BUS_TICK_TIMING.md
+++ b/docs/debugging/BUS_TICK_TIMING.md
@@ -92,7 +92,9 @@ inside it.
 
 - `cpu_interrupts_v2` needs interrupts sampled on the penultimate cycle of
   each instruction (and branch-specific behaviour), not at the boundary.
-  Tracked separately.
+  Landed as issue 10; see docs/debugging/INTERRUPT_LINE.md, "Sampling
+  Point". Tests 1, 2 and 4 pass; 3 and 5 wait on PPU vblank alignment and
+  APU frame-flag timing respectively.
 - `ppu_vbl_nmi` 02 and 05-10 need exact vblank set/clear dots and NMI
   suppression; `apu_test` 1, 5 and 6 need exact length-counter and IRQ
   flag timing. Both are Phase 5 material now that the bus is cycle-exact.

--- a/docs/debugging/INTERRUPT_LINE.md
+++ b/docs/debugging/INTERRUPT_LINE.md
@@ -3,8 +3,8 @@
 **Date:** 2026-09-04
 **Type:** Architectural Fix (CPU interrupt machinery, APU IRQ sources)
 **Severity:** Critical (games that rely on IRQs could not run)
-**Status:** Complete (CPU/APU half 2026-09-04, MMC3 half 2026-09-05)
-**Issue:** #3 (Phase 3 of docs/plans/ACCURACY_ROADMAP.md)
+**Status:** Complete (CPU/APU half 2026-09-04, MMC3 half 2026-09-05, sampling point 2026-09-05)
+**Issue:** #3 (Phase 3 of docs/plans/ACCURACY_ROADMAP.md); sampling point #10
 
 ## Executive Summary
 
@@ -76,7 +76,8 @@ the bottom of the function; that reasoning no longer applies but the spot is
 still the right one.)
 
 Hardware actually samples the interrupt inputs during the penultimate cycle
-of each instruction, not at the boundary; that refinement is issue 10.
+of each instruction, not at the boundary; see "Sampling Point" below
+(issue 10), which keeps the poll here but has it consume a snapshot.
 
 The interrupt sequence declares 7 cycles; `cpu_step` pads the two cycles that
 the five bus accesses (three pushes, two vector reads) do not cover.
@@ -193,10 +194,8 @@ every channel timer, so audio pitch changes; this needs a listening pass.
 
 ## Known Limitations
 
-- **No interrupt hijacking / one-instruction I-flag delay.** Hardware polls
-  during the last cycle of an instruction, so CLI/SEI/PLP/RTI changes to I
-  take effect one instruction late and a BRK can be hijacked by an NMI.
-  `cpu_interrupts_v2` tests 2-5 exercise these; they are Phase 4 material.
+- **Interrupt hijacking and the I-flag delay** landed with the sampling
+  point (below).
 - **No DMC DMA stall.** Each DMC byte fetch steals up to 4 CPU cycles on
   hardware; not modelled.
 - **$4017 write delay.** The sequencer reset takes effect 3-4 CPU cycles after
@@ -260,8 +259,180 @@ rather than batched at 257; that is Phase 5. Test 6 checks the alternate MMC3
 revision, which behaves differently from test 5 on reload-to-zero, so an
 emulator passes one of the two by design.
 
+## Sampling Point (landed 2026-09-05, issue 10)
+
+**Files:** `src/system.rs`, `src/system/tests.rs`, `tests/blargg.rs`
+
+### What hardware does
+
+The 6502 has an edge detector on NMI and a level detector on IRQ. Both look
+at their input during phi2 of every cycle and raise an internal signal that
+the instruction logic polls "before the last cycle" of each instruction.
+The net effect is one cycle of latency: an input asserted during the
+penultimate cycle of an instruction is serviced after that instruction; one
+asserted during the last cycle is not seen until the next instruction's
+poll, so the next instruction always runs first. On top of that:
+
+- CLI, SEI and PLP write P during their last cycle, after the poll has
+  already read the old I flag. The change to I is therefore only effective
+  for the poll of the following instruction (the flag itself changes at
+  once: CLI then PHP pushes I clear). RTI pulls P earlier and is not delayed.
+- BRK and the interrupt sequences do not poll at their end, so at least one
+  handler instruction always executes. If an NMI edge was captured by
+  `tick` during their cycles 1-4, or was already pending when the sequence
+  started (that is, visible to a poll in cycles 1-5), the vector fetched in
+  cycles 6-7 is $FFFA instead of $FFFE ("hijacking"); BRK still pushes P
+  with B set.
+- A taken branch that does not cross a page polls only before its second
+  cycle. An interrupt arriving during its last two cycles waits one more
+  instruction. A not-taken (2 cycle) or page-crossing (4 cycle) branch
+  polls normally.
+
+### How the row counts in the readme pin this down
+
+`test-roms/cpu_interrupts_v2/readme.txt` lists the result for each
+one-cycle shift of the interrupt against a fixed instruction stream. Calling
+`v` the first cycle whose poll can see the input (the cycle after it was
+asserted), test 2 (`CLC BRK SEC`) shows 1 row before CLC, 2 rows after CLC,
+5 hijack rows and 2 rows after SEC: `v` in BRK cycles 1-5 hijacks, `v` in
+BRK cycles 6-7 is not polled by BRK and lands after SEC. Test 3 (`LDA CLC
+[IRQ] SEC`) shows 7 rows of "NMI interrupting IRQ": `v` in CLC cycles 1-2
+(NMI wins over the IRQ at the boundary) plus IRQ-sequence cycles 1-5
+(hijack), then 2 rows after SEC for cycles 6-7. Test 5 `test_branch_taken`
+shows the IRQ with `v` = branch cycle 3 landing after the 4-cycle LDA that
+follows (CK 05), where `test_jmp` takes it after the JMP.
+
+### Implementation
+
+Everything stays in `System`; the opcode arms are untouched except for
+CLI/SEI/PLP, BRK and `branch_taken`.
+
+1. **Capture per tick.** `tick` calls `sample_interrupt_inputs` after the
+   PPU and APU have advanced and *before* the bus access of that tick. It
+   moves the PPU edge latch (`ppu.nmi_interrupt`) into `nmi_pending`,
+   remembering the tick at which it was first seen (`nmi_seen_tick`), and
+   records the IRQ line level (APU OR mapper OR `mapper_irq`) as bit
+   `tick - 1` of `irq_hist` (ticks beyond 16 are not recorded; the sample
+   tick is never past 7).
+2. **Snapshot at the end of the instruction.** `cpu_step` pads to the
+   declared cycle count as before, then `take_interrupt_snapshot(declared)`
+   reads back the capture at `sample_tick`: `declared - 1`, or 1 when
+   `branch_taken` set `poll_tick` for a non-crossing taken branch. It
+   produces `sampled_nmi` (NMI pending and seen at or before the sample
+   tick) and `sampled_irq` (level high at the sample tick, no NMI, and I
+   clear where I is the value CLI/SEI/PLP stashed in `i_flag_for_poll`
+   before modifying P, or the live flag otherwise). BRK and the sequences
+   set `no_poll`, which forces both to false.
+3. **Service at the boundary.** `poll_interrupts` at the top of the next
+   `cpu_step` consumes `sampled_nmi`/`sampled_irq`; it never reads the live
+   inputs. `nmi_pending` is cleared when the NMI is serviced (or when a
+   hijack takes it). An edge not taken by the previous instruction is
+   re-based to tick 0 at the start of the next one, so it is taken then.
+4. **Sequences.** `nmi()` and `irq()` now perform the two dummy reads of
+   cycles 1-2 and BRK reads its padding byte, so all three make exactly
+   seven bus accesses in hardware order and the hijack check
+   (`brk_or_irq_vector`: `nmi_pending && nmi_seen_tick <= 4`, evaluated
+   just before the vector read) lines up with cycle 5.
+
+Why the padding scheme does not get in the way: the sample tick is a tick
+index, and ticks 1..declared advance the PPU and APU in the same order as
+hardware cycles even when the bus accesses inside them are not in hardware
+order. Sampling *before* the access is what makes a padded instruction
+equivalent: for a read-modify-write or an indexed store the real access
+happens one tick earlier than on hardware (the dummy access is padded at
+the end), so the capture at tick `declared - 1`, taken before that tick's
+access, sees the same pre-access state hardware sees at its penultimate
+cycle. A write to `$2000` that enables NMI during vblank on the last tick
+of `STA $2000` is therefore first captured on tick 1 of the next
+instruction and serviced after it, which is what `ppu_vbl_nmi` 04 #11
+("immediate occurrence should be after NEXT instruction") checks.
+
+OAM DMA runs inside the `$4014` write, which is the last tick of the store;
+the store's sample tick precedes it, so an IRQ that rises during the DMA is
+taken after the instruction following the store (test 4 rows +11 to +526).
+
+### Results
+
+| Suite | Before | After |
+|-------|--------|-------|
+| cpu_interrupts_v2 1-cli_latency | #4 one instruction after CLI | pass |
+| cpu_interrupts_v2 2-nmi_and_brk | wrong rows | pass |
+| cpu_interrupts_v2 3-nmi_and_irq | wrong rows | rows shifted one cycle (see below) |
+| cpu_interrupts_v2 4-irq_and_dma | every offset one instruction early | pass |
+| cpu_interrupts_v2 5-branch_delays_irq | wrong PC column | PC column matches, CK column wrong (see below) |
+| cpu_interrupts_v2 combined | fails in test 1 | fails in test 3 |
+| ppu_vbl_nmi 04-nmi_control | #11 | pass |
+| nestest | 8991 lines | unchanged (registers, CYC, PPU column) |
+
+No other blargg suite changed; 38 pass, 38 remain ignored.
+
+### Still failing, and why (outside src/system.rs)
+
+**3-nmi_and_irq.** Our output is the expected table shifted one row: row 0
+already shows "NMI after LDA #1" (21) where hardware shows "before" (23),
+and there are three rows of 25 instead of two. The IRQ column is right (the
+IRQ lands after CLC in every row). The test syncs to vblank with
+`sync_vbl` (a `$2002` polling loop) and then waits about two frames before
+the sequence; test 2 uses the same sync but waits one frame and passes.
+Two NTSC frames are 59561.33 CPU cycles, so which cycle sees the second
+vblank depends on the sub-cycle PPU/CPU phase and on the exact cycle at
+which the vblank flag becomes readable through `$2002` (the sync's
+reference). Both are PPU-side: `ppu_vbl_nmi` 02 (vbl_set_time) and 05-08
+are the tests for them, tracked under the Phase 5 PPU issues. The
+interrupt sampling itself is not implicated because test 2 (same NMI path,
+same sync) and test 4 (IRQ path, 527 offsets) are exact.
+
+**5-branch_delays_irq.** The PC column, which is the observable for the
+branch rule (which instruction the IRQ was taken after), matches the readme
+for `test_jmp`, and the unit test
+`taken_branch_without_page_cross_delays_irq_from_its_second_cycle` checks
+the special case directly. The CK column is measured by the test's IRQ
+handler: it delays 29830 - 13 cycles, then loops `dex; delay 29831 - 13;
+bit $4015; bit $4015; bvc` until it observes the APU frame flag, which
+gives the IRQ's phase inside the frame period with one-cycle resolution.
+That needs the frame IRQ flag to be raised on exactly the three cycles
+hardware raises it and a 29830-cycle period; our `Apu` uses a 7457-cycle
+step (29828) and a single set, so CK prints a constant 05/06. This is the
+same defect `apu_test` 6 (irq_flag_timing, "flag first set too soon")
+reports, in `src/apu/mod.rs`.
+
+**Combined ROM.** Stops at the first failing sub-test (3).
+
+### Tests
+
+`src/system/tests.rs` (15 tests): every "arm a source, then step" test now
+executes one instruction before the 7-cycle sequence, which is the one
+instruction of latency. New: `cli_takes_effect_one_instruction_late`,
+`cli_sei_allows_exactly_one_irq_with_i_set_in_pushed_status`,
+`plp_delays_i_flag_but_rti_does_not`,
+`irq_asserted_on_penultimate_cycle_is_taken_after_that_instruction`,
+`irq_asserted_on_last_cycle_waits_one_more_instruction` (both land the APU
+frame flag on a chosen tick of a NOP by pre-stepping the APU, since `tick`
+performs exactly one `apu.step()`),
+`taken_branch_without_page_cross_delays_irq_from_its_second_cycle` (JMP
+versus BCC-to-next with the flag on tick 2),
+`nmi_during_brk_hijacks_its_vector` and
+`nmi_during_irq_sequence_hijacks_its_vector`.
+
+### Debugging notes
+
+- First attempt: the poll consumed the snapshot correctly but every
+  existing unit test expecting `cpu_step() == 7` immediately after arming a
+  source failed with 2. That is the intended one-instruction latency, not
+  a bug; the tests were updated rather than the model.
+- Test 5 printed a constant CK of 05/06 both before and after the change,
+  which pointed away from the CPU: the handler source (fetched from the
+  public nes-test-roms mirror) confirmed CK is an APU frame-flag phase
+  measurement.
+- Test 4 moved from "every IRQ one instruction early" to exact with no
+  DMA changes, confirming the DMA parity cycle was already right.
+
 ## References
 
-- nesdev wiki: CPU interrupts, APU Frame Counter, APU DMC, APU $4015
+- nesdev wiki: CPU interrupts (including "Delayed IRQ response after CLI,
+  SEI, and PLP", "Interrupt hijacking" and "Branch instructions and
+  interrupts"), APU Frame Counter, APU DMC, APU $4015
+- test-roms/cpu_interrupts_v2/readme.txt and the test sources in the
+  nes-test-roms mirror (cpu_interrupts_v2/source)
 - docs/plans/ACCURACY_ROADMAP.md, Phase 3
 - docs/debugging/PPU_CYCLE_ACCURATE_REFACTOR.md (NMI generation in the PPU)

--- a/docs/testing/TEST_ROM_HARNESS.md
+++ b/docs/testing/TEST_ROM_HARNESS.md
@@ -129,8 +129,8 @@ arms, so the unimplemented-opcode fallback was removed.
 |-------|------|---------|------------------------|
 | instr_test-v5 (16 singles + 2 combined) | 18 | 0 | |
 | cpu_timing_test6 | 1 | 0 | |
-| cpu_interrupts_v2 (5 + 1) | 0 | 6 | no IRQ line: 1 fails #3 (APU IRQ), 2/3/5 hang, 4 wrong DMA offsets, combined fails in test 1 |
-| ppu_vbl_nmi (10 + 1) | 2 | 9 | 01 and 03 pass since bus-tick timing (Phase 4); 04 #11 NMI after next instruction; 02/05-10 need exact vblank dots (Phase 5) |
+| cpu_interrupts_v2 (5 + 1) | 3 | 3 | 1, 2 and 4 pass since the sampling point landed (issue 10); 3 rows shifted one cycle (PPU vblank/$2002 alignment after a two-frame wait); 5 PC column right, CK column needs exact APU frame-flag timing (as apu_test 6); combined stops at 3 |
+| ppu_vbl_nmi (10 + 1) | 3 | 8 | 01 and 03 pass since bus-tick timing (Phase 4), 04 since issue 10; 02/05-10 need exact vblank dots (Phase 5) |
 | ppu_open_bus | 1 | 0 | passes since issues 13 (decay latch) and 14 (attribute masking) |
 | sprite_hit_tests_2005.10.05 (11) | 1 | 10 | 11 passes since Phase 4; 01 #7, 02 #2, 03 #2, 04 #2, 05 #4, 06 #3, 07 #6, 08 #3; 09/10 hang |
 | sprite_overflow_tests (5) | 1 | 4 | 1 #7, 2 #9, 4 #7, 3 hangs; 5.Emulator passes |
@@ -139,9 +139,10 @@ arms, so the unimplemented-opcode fallback was removed.
 | oam_read | 1 | 0 | |
 | oam_stress | 1 | 0 | passes since attribute bits 2-4 are masked (issue 14) |
 | mmc3_test_2 (6) | 4 | 2 | 4 needs cycle-exact sprite fetch positions (Phase 5); 6 is the alternate revision, exclusive with 5 |
-| **Total blargg** | **36** | **40** | |
+| **Total blargg** | **40** | **36** | |
 
-Combined with nestest: 42 tests pass, 41 are ignored.
+Combined with nestest (7 tests): 47 integration tests pass, 36 are ignored,
+plus the ignored game_frames fingerprint run.
 
 ### Expected progression
 
@@ -150,8 +151,8 @@ Combined with nestest: 42 tests pass, 41 are ignored.
 | CPU fix for `$B4` (small, can ride with any phase) | instr_test-v5 05/official_only/all_instrs, nestest full register compare, likely `cpu_timing_test6` moves to a timing failure |
 | Phase 3 (IRQ line, NMI edge) | cpu_interrupts_v2, apu_reset (landed: apu_test 2/3/4/7/8 and mmc3_test_2 1/2/3/5 pass) |
 | Phase 4 (bus-tick timing) | landed: ppu_vbl_nmi 01/03 and sprite_hit 11 now pass |
-| Phase 5 (PPU cycle detail) | sprite_hit_tests, sprite_overflow_tests, mmc3_test_2 4, ppu_vbl_nmi 02/04-10, apu_test 1/5/6 (landed: oam_stress via issue 14, ppu_open_bus via issues 13 and 14) |
-| Interrupt sampling (follow-up issue) | cpu_interrupts_v2 |
+| Phase 5 (PPU cycle detail) | sprite_hit_tests, sprite_overflow_tests, mmc3_test_2 4, ppu_vbl_nmi 02/05-10, cpu_interrupts_v2 3, apu_test 1/5/6 (and cpu_interrupts_v2 5 with the APU frame-flag fix); landed: oam_stress via issue 14, ppu_open_bus via issues 13 and 14 |
+| Interrupt sampling (issue 10) | landed: cpu_interrupts_v2 1/2/4 and ppu_vbl_nmi 04 now pass |
 
 ## Debug API reference (`src/system.rs`)
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -43,9 +43,34 @@ pub struct System {
     /// `set_total_cpu_cycles` call. Unlike `cycles` (a per-frame budget)
     /// this never resets; it feeds the nestest-style trace CYC column.
     total_cycles: u64,
-    /// Latched rising edge of the PPU NMI output. NMI is edge-triggered: the
-    /// edge is captured here and serviced exactly once by `poll_interrupts`.
+    /// Latched rising edge of the PPU NMI output (the CPU's edge detector).
+    /// NMI is edge-triggered: the edge is captured here in `tick` and
+    /// serviced exactly once by `poll_interrupts`.
     nmi_pending: bool,
+    /// Tick of the current instruction (1-based) at which `nmi_pending` was
+    /// raised; 0 when it was already pending when the instruction began.
+    /// The boundary poll only takes the NMI if this is at or before the
+    /// instruction's sample tick (see `sample_tick`).
+    nmi_seen_tick: u16,
+    /// IRQ line level captured at each tick of the current instruction,
+    /// bit `k - 1` for tick `k` (ticks past 16 are not recorded; the sample
+    /// tick is never later than 7). See `tick`.
+    irq_hist: u16,
+    /// Sample tick override for the current instruction. 0 means the
+    /// default, `declared - 1` (the penultimate cycle). A taken branch that
+    /// does not cross a page sets it to 1.
+    poll_tick: u16,
+    /// Set by BRK and the interrupt sequences: these do not poll at their
+    /// end, so at least one handler instruction always runs first.
+    no_poll: bool,
+    /// Set by CLI, SEI and PLP to the I flag as it was before the
+    /// instruction. The IRQ poll at the end of those instructions uses the
+    /// old value, so a change to I is only seen one instruction later.
+    i_flag_for_poll: Option<bool>,
+    /// Result of the previous instruction's interrupt poll, consumed by
+    /// `poll_interrupts` at the start of the next `cpu_step`.
+    sampled_nmi: bool,
+    sampled_irq: bool,
     /// Extra mapper-style contribution to the IRQ line (level), OR'd with the
     /// loaded mapper's own `irq_pending()`. Used by tests to drive the line
     /// without a cartridge that has an IRQ counter.
@@ -81,6 +106,13 @@ impl System {
             audio_capture: false,
             total_cycles: 0,
             nmi_pending: false,
+            nmi_seen_tick: 0,
+            irq_hist: 0,
+            poll_tick: 0,
+            no_poll: false,
+            i_flag_for_poll: None,
+            sampled_nmi: false,
+            sampled_irq: false,
             mapper_irq: false,
         }
     }
@@ -107,6 +139,12 @@ impl System {
         for _ in 0..5 {
             self.tick();
         }
+        // Nothing sampled during the reset sequence is taken: the first
+        // instruction after reset always runs.
+        self.nmi_pending = false;
+        self.irq_hist = 0;
+        self.sampled_nmi = false;
+        self.sampled_irq = false;
         log::info!("Reset CPU, PC set to: 0x{:04X}", self.cpu_pc);
 
         // Log first few bytes at reset vector for debugging
@@ -142,6 +180,21 @@ impl System {
     /// APU step, the cycle counters and audio sampling. Every bus access
     /// calls this first, so PPU and APU registers are observed at the cycle
     /// the access really happens rather than after the instruction.
+    ///
+    /// After the PPU and APU have advanced, and before the access that
+    /// follows this tick, the interrupt inputs are captured: a PPU NMI edge
+    /// is latched into `nmi_pending` (recording the tick it was first seen)
+    /// and the IRQ line level is recorded in `irq_hist`. The poll at the end
+    /// of the instruction reads back the capture from its sample tick
+    /// (`sample_tick`), which is how the hardware's one-cycle detector
+    /// latency is modelled: an input asserted during the last cycle of an
+    /// instruction is not seen until the next instruction's poll.
+    ///
+    /// Sampling before the access matters because of padding: for a
+    /// read-modify-write or an indexed store the real access happens one
+    /// tick earlier than on hardware (the dummy access is padded at the
+    /// end), so sampling at tick `declared - 1` before its access sees the
+    /// same pre-access state hardware sees at its penultimate cycle.
     fn tick(&mut self) {
         self.total_cycles += 1;
         self.instr_cycles += 1;
@@ -149,6 +202,7 @@ impl System {
             self.ppu_step();
         }
         self.apu.step();
+        self.sample_interrupt_inputs();
 
         if self.audio_capture {
             const CYCLES_PER_SAMPLE: f64 = 1_789_773.0 / 44_100.0;
@@ -274,11 +328,17 @@ impl System {
     fn cpu_step(&mut self) -> u16 {
         self.instr_cycles = 0;
         self.dma_in_instr = false;
+        self.irq_hist = 0;
+        self.poll_tick = 0;
+        self.no_poll = false;
+        self.i_flag_for_poll = None;
+        // An edge latched on the previous instruction's last tick (or left
+        // over from a non-polling sequence) counts as pending from tick 0.
+        self.nmi_seen_tick = 0;
 
-        // Interrupt polling happens at the boundary between the previous
-        // instruction and the next opcode fetch. Every cycle of the previous
-        // instruction has already been ticked, so the PPU NMI latch and the
-        // APU/mapper IRQ levels seen here are the ones at that boundary.
+        // The interrupt poll consumes the snapshot the previous instruction
+        // took at its sample tick (see `tick` and `sample_tick`), never the
+        // live inputs.
         let declared = match self.poll_interrupts() {
             Some(cycles) => cycles as u16,
             None => self.execute_opcode() as u16,
@@ -301,7 +361,65 @@ impl System {
         while self.instr_cycles < declared {
             self.tick();
         }
+
+        self.take_interrupt_snapshot(declared);
         self.instr_cycles
+    }
+
+    /// The tick of an instruction whose captured inputs the boundary poll
+    /// uses: the penultimate cycle for everything except a taken branch
+    /// that does not cross a page, which only polls before its second
+    /// cycle (so an interrupt arriving during its last two cycles waits
+    /// one more instruction).
+    fn sample_tick(&self, declared: u16) -> u16 {
+        if self.poll_tick != 0 {
+            self.poll_tick
+        } else {
+            declared.saturating_sub(1).max(1)
+        }
+    }
+
+    /// Capture the interrupt inputs at this tick. Called from `tick` after
+    /// the PPU and APU have advanced and before the tick's bus access.
+    fn sample_interrupt_inputs(&mut self) {
+        if self.ppu.nmi_interrupt {
+            self.ppu.nmi_interrupt = false;
+            // A second edge before the first is serviced is dropped, as on
+            // hardware; only the first one's tick is remembered.
+            if !self.nmi_pending {
+                self.nmi_pending = true;
+                self.nmi_seen_tick = self.instr_cycles;
+            }
+        }
+        if self.instr_cycles <= 16 && self.irq_line() {
+            self.irq_hist |= 1 << (self.instr_cycles - 1);
+        }
+    }
+
+    /// Level of the IRQ line: the OR of every source.
+    fn irq_line(&self) -> bool {
+        self.apu.irq_pending()
+            || self.mapper_irq
+            || self
+                .cartridge
+                .as_ref()
+                .is_some_and(|cart| cart.mapper.irq_pending())
+    }
+
+    /// Decide, at the end of an instruction, which interrupt (if any) the
+    /// next `cpu_step` services, from the inputs captured at the sample
+    /// tick. BRK and the interrupt sequences never poll.
+    fn take_interrupt_snapshot(&mut self, declared: u16) {
+        if self.no_poll {
+            self.sampled_nmi = false;
+            self.sampled_irq = false;
+            return;
+        }
+        let tick = self.sample_tick(declared);
+        self.sampled_nmi = self.nmi_pending && self.nmi_seen_tick <= tick;
+        let irq_level = tick <= 16 && self.irq_hist & (1 << (tick - 1)) != 0;
+        let i_set = self.i_flag_for_poll.unwrap_or(self.cpu_status & 0x04 != 0);
+        self.sampled_irq = !self.sampled_nmi && irq_level && !i_set;
     }
 
     fn execute_opcode(&mut self) -> u8 {
@@ -436,7 +554,8 @@ impl System {
             }
             // More opcodes needed for Super Mario Bros
             0x78 => {
-                // SEI
+                // SEI. The I flag change is polled one instruction late.
+                self.i_flag_for_poll = Some(self.cpu_status & 0x04 != 0);
                 self.cpu_status |= 0x04;
                 2
             }
@@ -547,10 +666,16 @@ impl System {
                 // only ever a property of the pushed copy; it is never set in
                 // the live status register (that would leak into the P pushed
                 // by an NMI arriving inside the BRK handler).
+                //
+                // Like the interrupt sequences, BRK does not poll at its
+                // end, and an NMI edge seen by cycle 5 hijacks its vector.
+                self.no_poll = true;
+                self.read_byte(self.cpu_pc); // padding byte, discarded
                 self.push_word(self.cpu_pc.wrapping_add(1));
                 self.push(self.cpu_status | 0x30);
                 self.cpu_status |= 0x04;
-                self.cpu_pc = self.read_word(0xFFFE);
+                let vector = self.brk_or_irq_vector();
+                self.cpu_pc = self.read_word(vector);
                 7
             }
             0x40 => {
@@ -576,7 +701,9 @@ impl System {
                 3
             }
             0x28 => {
-                // PLP
+                // PLP. Like CLI/SEI, the new I flag is polled one
+                // instruction late (RTI is not delayed).
+                self.i_flag_for_poll = Some(self.cpu_status & 0x04 != 0);
                 self.cpu_status = self.pop() & 0xEF | 0x20;
                 4
             }
@@ -1126,7 +1253,10 @@ impl System {
                 2
             }
             0x58 => {
-                // CLI - Clear interrupt disable
+                // CLI - Clear interrupt disable. The I flag change is polled
+                // one instruction late: the next instruction always runs
+                // before a pending IRQ is taken.
+                self.i_flag_for_poll = Some(self.cpu_status & 0x04 != 0);
                 self.cpu_status &= !0x04;
                 2
             }
@@ -2591,12 +2721,17 @@ impl System {
 
     /// Apply a taken branch. Costs 3 cycles, or 4 when the target is on a
     /// different page from the address of the next instruction.
+    ///
+    /// A taken branch that does not cross a page polls interrupts only
+    /// before its second cycle, so its sample tick is 1 rather than the
+    /// penultimate cycle (cpu_interrupts_v2 test 5).
     fn branch_taken(&mut self, offset: i8) -> u8 {
         let next = self.cpu_pc;
         self.cpu_pc = next.wrapping_add(offset as u16);
         if Self::page_crossed(next, self.cpu_pc) {
             4
         } else {
+            self.poll_tick = 1;
             3
         }
     }
@@ -2687,13 +2822,18 @@ impl System {
         ppu.step(mapper);
     }
 
-    /// Poll the interrupt inputs at an instruction boundary and service one
-    /// if due. Returns the cycles consumed (7) when an interrupt sequence ran.
+    /// Service the interrupt the previous instruction sampled, if any.
+    /// Returns the cycles consumed (7) when an interrupt sequence ran.
+    ///
+    /// This consumes the snapshot taken by `take_interrupt_snapshot` at the
+    /// previous instruction's sample tick, never the live inputs: an input
+    /// asserted during an instruction's last cycle is not seen here.
     ///
     /// NMI is edge-triggered: the PPU raises `nmi_interrupt` exactly once per
     /// rising edge of its NMI output (vblank start with NMI enabled, or NMI
-    /// enabled during vblank) and we consume that latch here, so each edge is
-    /// serviced once no matter how long the output stays high.
+    /// enabled during vblank); `tick` latches it into `nmi_pending`, which
+    /// is cleared here, so each edge is serviced once no matter how long the
+    /// output stays high.
     ///
     /// IRQ is level-triggered: the line is the OR of every IRQ source and is
     /// serviced whenever it is high and the I flag is clear. The sources hold
@@ -2702,32 +2842,24 @@ impl System {
     ///
     /// NMI has priority over IRQ.
     fn poll_interrupts(&mut self) -> Option<u8> {
-        if self.ppu.nmi_interrupt {
-            self.ppu.nmi_interrupt = false;
-            self.nmi_pending = true;
-        }
-
-        if self.nmi_pending {
+        if self.sampled_nmi {
+            self.sampled_nmi = false;
+            self.sampled_irq = false;
             self.nmi_pending = false;
             self.nmi();
             return Some(7);
         }
-
-        let mapper_irq = self.mapper_irq
-            || self
-                .cartridge
-                .as_ref()
-                .is_some_and(|cart| cart.mapper.irq_pending());
-        let irq_line = self.apu.irq_pending() || mapper_irq;
-        if irq_line && (self.cpu_status & 0x04) == 0 {
+        if self.sampled_irq {
+            self.sampled_irq = false;
             self.irq();
             return Some(7);
         }
-
         None
     }
 
     fn nmi(&mut self) {
+        self.no_poll = true;
+        self.interrupt_dummy_reads();
         self.push_word(self.cpu_pc);
         // Hardware interrupts push P with B (bit 4) clear and bit 5 set.
         self.push((self.cpu_status & !0x10) | 0x20);
@@ -2736,11 +2868,33 @@ impl System {
     }
 
     fn irq(&mut self) {
+        self.no_poll = true;
+        self.interrupt_dummy_reads();
         self.push_word(self.cpu_pc);
         // Same vector as BRK, but B is clear so the handler can distinguish.
         self.push((self.cpu_status & !0x10) | 0x20);
         self.cpu_status |= 0x04; // Set interrupt disable
-        self.cpu_pc = self.read_word(0xFFFE);
+        let vector = self.brk_or_irq_vector();
+        self.cpu_pc = self.read_word(vector);
+    }
+
+    /// Cycles 1 and 2 of the interrupt sequence: the opcode fetch that the
+    /// interrupt replaced and the following dummy read, both discarded.
+    fn interrupt_dummy_reads(&mut self) {
+        self.read_byte(self.cpu_pc);
+        self.read_byte(self.cpu_pc);
+    }
+
+    /// Interrupt hijacking: BRK and the IRQ sequence pick their vector
+    /// during the P push (cycle 5). An NMI edge seen by then diverts them
+    /// to the NMI vector, and the NMI is thereby serviced.
+    fn brk_or_irq_vector(&mut self) -> u16 {
+        if self.nmi_pending && self.nmi_seen_tick <= 4 {
+            self.nmi_pending = false;
+            0xFFFA
+        } else {
+            0xFFFE
+        }
     }
 
     // ------------------------------------------------------------------
@@ -2853,8 +3007,9 @@ impl System {
     /// Execute exactly one CPU instruction (or interrupt sequence) and
     /// return the CPU cycles consumed. The PPU and APU advance inside the
     /// instruction's bus accesses, an OAM DMA started by a `$4014` write runs
-    /// to completion inside the instruction, and NMI/IRQ are polled at the
-    /// instruction boundary, exactly as in `run_frame`.
+    /// to completion inside the instruction, and NMI/IRQ are sampled on the
+    /// instruction's penultimate cycle and serviced at the boundary, exactly
+    /// as in `run_frame`.
     pub fn step_instruction(&mut self) -> u32 {
         self.cpu_step() as u32
     }

--- a/src/system/tests.rs
+++ b/src/system/tests.rs
@@ -1,9 +1,16 @@
-//! Interrupt-line tests for the CPU: NMI edge, IRQ level, BRK/IRQ B flag.
+//! Interrupt-line tests for the CPU: NMI edge, IRQ level, BRK/IRQ B flag,
+//! and the sampling point (docs/debugging/INTERRUPT_LINE.md, issue 10).
 //!
 //! Each test builds a System with a synthetic 32 KB NROM cartridge whose PRG
 //! is filled with NOPs and whose vectors point at distinct, recognisable
 //! addresses. `cpu_step` is driven directly so the tests are independent of
 //! the PPU frame loop.
+//!
+//! Interrupt inputs are sampled during the penultimate cycle of each
+//! instruction, so a source that is already asserted when a test starts
+//! stepping is first seen during the next instruction and serviced after
+//! it: every "arm, then step" sequence below runs one instruction before
+//! the 7-cycle interrupt sequence.
 
 use super::System;
 use crate::cartridge::Cartridge;
@@ -15,6 +22,11 @@ const IRQ_VECTOR: u16 = 0xA000;
 const NOP: u8 = 0xEA;
 const BRK: u8 = 0x00;
 const CLI: u8 = 0x58;
+const SEI: u8 = 0x78;
+const PLP: u8 = 0x28;
+const RTI: u8 = 0x40;
+const JMP_ABS: u8 = 0x4C;
+const BCC: u8 = 0x90;
 
 /// Build an iNES image: 16-byte header, 32 KB PRG (mapper 0), no CHR ROM
 /// (the loader zero-fills 8 KB of CHR RAM).
@@ -69,11 +81,50 @@ fn raise_apu_frame_irq(system: &mut System) {
     }
 }
 
+/// Number of `apu.step()` calls after the `$4017` write before the frame
+/// IRQ flag rises. `tick` performs exactly one `apu.step()`, so stepping
+/// the APU `n - k` times by hand makes the flag rise on tick `k` of the
+/// next instruction.
+fn apu_steps_to_frame_irq() -> u32 {
+    let mut sys = system();
+    sys.write_byte(0x4017, 0x00);
+    let mut steps = 0u32;
+    while !sys.apu.irq_pending() {
+        sys.apu.step();
+        steps += 1;
+        assert!(steps < 40_000, "APU frame IRQ never asserted");
+    }
+    steps
+}
+
+/// Arm the APU so the frame IRQ flag rises on tick `tick` of the next
+/// instruction, with I clear.
+fn arm_apu_irq_for_tick(sys: &mut System, tick: u32) {
+    let n = apu_steps_to_frame_irq();
+    sys.write_byte(0x4017, 0x00);
+    for _ in 0..(n - tick) {
+        sys.apu.step();
+    }
+    assert!(!sys.apu.irq_pending(), "flag must not be up yet");
+    sys.cpu_status &= !0x04;
+}
+
+/// Push a return address and status byte as an interrupt would, so RTI or
+/// PLP can pull them.
+fn push_frame(sys: &mut System, pc: u16, p: u8) {
+    sys.push_word(pc);
+    sys.push(p);
+}
+
 #[test]
 fn irq_taken_when_i_clear_and_apu_frame_flag_set() {
     let mut sys = system();
     raise_apu_frame_irq(&mut sys);
     sys.cpu_status &= !0x04; // clear I
+
+    // The line was already high, so it is seen during the first tick of
+    // this NOP (its penultimate cycle) and serviced after it.
+    assert_eq!(sys.cpu_step(), 2, "one instruction runs first");
     let sp_before = sys.cpu_sp;
     let pc_before = sys.cpu_pc;
 
@@ -119,15 +170,61 @@ fn irq_not_taken_when_i_set() {
 }
 
 #[test]
-fn irq_taken_after_cli_while_line_held() {
-    // The line is level-triggered: a pending source is picked up as soon as
-    // software clears I, even though it was ignored earlier.
+fn cli_takes_effect_one_instruction_late() {
+    // The line is level-triggered and held, but CLI's poll still uses the
+    // old I flag: the instruction after CLI runs before the IRQ is taken.
     let mut sys = system_with_rom(|prg| prg[0] = CLI);
     raise_apu_frame_irq(&mut sys);
 
     assert_eq!(sys.cpu_step(), 2, "CLI executes normally");
+    assert_eq!(sys.cpu_status & 0x04, 0, "the flag itself changes at once");
+    assert_eq!(
+        sys.cpu_step(),
+        2,
+        "the next instruction runs before the IRQ"
+    );
+    assert_eq!(sys.cpu_pc, RESET_VECTOR + 2);
+    assert_eq!(sys.cpu_step(), 7, "IRQ serviced after that");
+    assert_eq!(sys.cpu_pc, IRQ_VECTOR);
+}
+
+#[test]
+fn cli_sei_allows_exactly_one_irq_with_i_set_in_pushed_status() {
+    // cpu_interrupts_v2 1-cli_latency tests 5 and 6.
+    let mut sys = system_with_rom(|prg| {
+        prg[0] = CLI;
+        prg[1] = SEI;
+    });
+    raise_apu_frame_irq(&mut sys);
+
+    assert_eq!(sys.cpu_step(), 2, "CLI");
+    assert_eq!(sys.cpu_step(), 2, "SEI runs: CLI's poll used the old I");
+    let sp_before = sys.cpu_sp;
+    assert_eq!(sys.cpu_step(), 7, "SEI's poll used the old (clear) I");
+    assert_eq!(sys.cpu_pc, IRQ_VECTOR);
+    let pushed_p = stack_byte(&sys, 0x0100 | sp_before.wrapping_sub(2) as u16);
+    assert_ne!(pushed_p & 0x04, 0, "the pushed status already has I set");
+}
+
+#[test]
+fn plp_delays_i_flag_but_rti_does_not() {
+    // PLP: the pulled I flag is polled one instruction late.
+    let mut sys = system_with_rom(|prg| prg[0] = PLP);
+    sys.mapper_irq = true;
+    push_frame(&mut sys, 0, 0x20); // P with I clear (only the byte matters)
+    assert_eq!(sys.cpu_step(), 4, "PLP");
     assert_eq!(sys.cpu_status & 0x04, 0);
-    assert_eq!(sys.cpu_step(), 7, "IRQ serviced at the next boundary");
+    assert_eq!(sys.cpu_step(), 2, "one more instruction before the IRQ");
+    assert_eq!(sys.cpu_step(), 7);
+    assert_eq!(sys.cpu_pc, IRQ_VECTOR);
+
+    // RTI: the pulled I flag is effective immediately.
+    let mut sys = system_with_rom(|prg| prg[0] = RTI);
+    sys.mapper_irq = true;
+    push_frame(&mut sys, RESET_VECTOR + 0x10, 0x20);
+    assert_eq!(sys.cpu_step(), 6, "RTI");
+    assert_eq!(sys.cpu_pc, RESET_VECTOR + 0x10);
+    assert_eq!(sys.cpu_step(), 7, "IRQ taken straight after RTI");
     assert_eq!(sys.cpu_pc, IRQ_VECTOR);
 }
 
@@ -137,6 +234,7 @@ fn irq_acknowledged_by_4015_read_stops_retriggering() {
     raise_apu_frame_irq(&mut sys);
     sys.cpu_status &= !0x04;
 
+    assert_eq!(sys.cpu_step(), 2);
     assert_eq!(sys.cpu_step(), 7);
     assert_eq!(sys.cpu_pc, IRQ_VECTOR);
 
@@ -159,18 +257,70 @@ fn mapper_irq_input_drives_the_line() {
     sys.cpu_status &= !0x04;
     sys.mapper_irq = true;
 
+    assert_eq!(sys.cpu_step(), 2);
     assert_eq!(sys.cpu_step(), 7);
+    assert_eq!(sys.cpu_pc, IRQ_VECTOR);
+}
+
+#[test]
+fn irq_asserted_on_penultimate_cycle_is_taken_after_that_instruction() {
+    let mut sys = system();
+    arm_apu_irq_for_tick(&mut sys, 1); // tick 1 of a 2-cycle NOP
+    assert_eq!(sys.cpu_step(), 2, "NOP");
+    assert!(sys.apu.irq_pending(), "flag rose inside the NOP");
+    assert_eq!(sys.cpu_step(), 7, "IRQ taken after the NOP");
+    assert_eq!(sys.cpu_pc, IRQ_VECTOR);
+}
+
+#[test]
+fn irq_asserted_on_last_cycle_waits_one_more_instruction() {
+    let mut sys = system();
+    arm_apu_irq_for_tick(&mut sys, 2); // tick 2 of a 2-cycle NOP: its last
+    assert_eq!(sys.cpu_step(), 2, "NOP");
+    assert!(sys.apu.irq_pending(), "flag rose inside the NOP");
+    assert_eq!(sys.cpu_step(), 2, "missed by the NOP's poll: next NOP runs");
+    assert_eq!(sys.cpu_step(), 7, "IRQ taken after that");
+    assert_eq!(sys.cpu_pc, IRQ_VECTOR);
+}
+
+#[test]
+fn taken_branch_without_page_cross_delays_irq_from_its_second_cycle() {
+    // JMP abs (3 cycles): an IRQ rising on tick 2 (penultimate) is taken
+    // after the JMP.
+    let mut sys = system_with_rom(|prg| {
+        prg[0] = JMP_ABS;
+        prg[1] = 0x03;
+        prg[2] = 0x80;
+    });
+    arm_apu_irq_for_tick(&mut sys, 2);
+    assert_eq!(sys.cpu_step(), 3, "JMP");
+    assert_eq!(sys.cpu_step(), 7, "IRQ taken after the JMP");
+
+    // BCC to the next instruction (taken, same page, 3 cycles): the same
+    // tick-2 IRQ is only seen by the following instruction.
+    let mut sys = system_with_rom(|prg| {
+        prg[0] = BCC;
+        prg[1] = 0x00;
+    });
+    assert_eq!(sys.cpu_status & 0x01, 0, "carry clear after reset");
+    arm_apu_irq_for_tick(&mut sys, 2);
+    assert_eq!(sys.cpu_step(), 3, "BCC taken");
+    assert_eq!(sys.cpu_pc, RESET_VECTOR + 2);
+    assert_eq!(sys.cpu_step(), 2, "the instruction after the branch runs");
+    assert_eq!(sys.cpu_step(), 7, "IRQ taken after that");
     assert_eq!(sys.cpu_pc, IRQ_VECTOR);
 }
 
 #[test]
 fn nmi_fires_once_per_edge() {
     let mut sys = system();
-    let sp_before = sys.cpu_sp;
 
     // Simulate the PPU raising its NMI output edge.
     sys.ppu.nmi_interrupt = true;
 
+    assert_eq!(sys.cpu_step(), 2, "the edge is seen during this NOP");
+    assert!(!sys.ppu.nmi_interrupt, "the edge latch is consumed");
+    let sp_before = sys.cpu_sp;
     assert_eq!(sys.cpu_step(), 7, "NMI sequence takes 7 cycles");
     assert_eq!(sys.cpu_pc, NMI_VECTOR, "NMI must vector through $FFFA");
     assert_eq!(sys.cpu_sp, sp_before.wrapping_sub(3));
@@ -180,7 +330,6 @@ fn nmi_fires_once_per_edge() {
         0x20,
         "NMI pushes P with B clear, bit 5 set"
     );
-    assert!(!sys.ppu.nmi_interrupt, "the edge latch is consumed");
 
     // With no new edge the NMI must not be serviced again, even with I clear.
     sys.cpu_status &= !0x04;
@@ -193,6 +342,7 @@ fn nmi_fires_once_per_edge() {
 
     // A second edge is serviced again.
     sys.ppu.nmi_interrupt = true;
+    assert_eq!(sys.cpu_step(), 2);
     assert_eq!(sys.cpu_step(), 7);
     assert_eq!(sys.cpu_pc, NMI_VECTOR);
 }
@@ -204,6 +354,7 @@ fn nmi_has_priority_over_irq() {
     sys.cpu_status &= !0x04;
     sys.ppu.nmi_interrupt = true;
 
+    assert_eq!(sys.cpu_step(), 2);
     assert_eq!(sys.cpu_step(), 7);
     assert_eq!(sys.cpu_pc, NMI_VECTOR, "NMI wins when both are pending");
     // NMI set I, so the IRQ waits; it is still asserted for later.
@@ -232,4 +383,42 @@ fn brk_pushes_b_flag_and_uses_irq_vector() {
         "B is never set in the live status register"
     );
     assert_ne!(sys.cpu_status & 0x04, 0, "BRK sets the I flag");
+}
+
+#[test]
+fn nmi_during_brk_hijacks_its_vector() {
+    // cpu_interrupts_v2 2-nmi_and_brk: an NMI edge seen during the first
+    // cycles of BRK sends it through $FFFA with B still set in the pushed
+    // status, and the NMI is thereby serviced (no second NMI sequence).
+    let mut sys = system_with_rom(|prg| prg[0] = BRK);
+    sys.ppu.nmi_interrupt = true; // seen on BRK's first tick
+    let sp_before = sys.cpu_sp;
+
+    assert_eq!(sys.cpu_step(), 7, "BRK");
+    assert_eq!(sys.cpu_pc, NMI_VECTOR, "hijacked to the NMI vector");
+    let pushed_p = stack_byte(&sys, 0x0100 | sp_before.wrapping_sub(2) as u16);
+    assert_eq!(pushed_p & 0x30, 0x30, "still BRK's status byte");
+
+    sys.cpu_status &= !0x04;
+    let sp_after = sys.cpu_sp;
+    for _ in 0..4 {
+        assert_eq!(sys.cpu_step(), 2, "the NMI is not serviced twice");
+    }
+    assert_eq!(sys.cpu_sp, sp_after);
+}
+
+#[test]
+fn nmi_during_irq_sequence_hijacks_its_vector() {
+    let mut sys = system();
+    sys.mapper_irq = true;
+    sys.cpu_status &= !0x04;
+    assert_eq!(sys.cpu_step(), 2);
+    sys.ppu.nmi_interrupt = true; // seen on the IRQ sequence's first tick
+    let sp_before = sys.cpu_sp;
+
+    assert_eq!(sys.cpu_step(), 7, "IRQ sequence");
+    assert_eq!(sys.cpu_pc, NMI_VECTOR, "hijacked to the NMI vector");
+    let pushed_p = stack_byte(&sys, 0x0100 | sp_before.wrapping_sub(2) as u16);
+    assert_eq!(pushed_p & 0x30, 0x20, "B clear as for any IRQ");
+    assert_eq!(sys.cpu_step(), 2, "handler's first instruction runs");
 }

--- a/tests/blargg.rs
+++ b/tests/blargg.rs
@@ -181,38 +181,36 @@ screen_test!(
 blargg_test!(
     cpu_interrupts_1_cli_latency,
     "cpu_interrupts_v2/rom_singles/1-cli_latency.nes",
-    SHORT,
-    ignore = "#3 APU should generate IRQ when $4017 = $00 (no IRQ line); Phase 3"
+    SHORT
 );
 blargg_test!(
     cpu_interrupts_2_nmi_and_brk,
     "cpu_interrupts_v2/rom_singles/2-nmi_and_brk.nes",
-    SHORT,
-    ignore = "hangs after printing NMI BRK header (no IRQ line); Phase 3"
+    SHORT
 );
 blargg_test!(
     cpu_interrupts_3_nmi_and_irq,
     "cpu_interrupts_v2/rom_singles/3-nmi_and_irq.nes",
     SHORT,
-    ignore = "hangs after printing NMI BRK header (no IRQ line); Phase 3"
+    ignore = "rows shifted one cycle (NMI seen one cycle late after a two-frame wait since sync_vbl); needs exact vblank flag/NMI dot and $2002 read alignment, see ppu_vbl_nmi 02; Phase 5"
 );
 blargg_test!(
     cpu_interrupts_4_irq_and_dma,
     "cpu_interrupts_v2/rom_singles/4-irq_and_dma.nes",
-    SHORT,
-    ignore = "fails, prints constant 53 for every DMA offset (no IRQ line, DMA not cycle-stepped); Phase 3/4"
+    SHORT
 );
 blargg_test!(
     cpu_interrupts_5_branch_delays_irq,
     "cpu_interrupts_v2/rom_singles/5-branch_delays_irq.nes",
     SHORT,
-    ignore = "hangs in test_jmp (no IRQ line); Phase 3"
+    ignore = "PC column (which instruction the IRQ followed) matches for test_jmp, CK column is constant 05/06: the handler measures phase against the APU frame flag, which needs the exact 29830-cycle period and 3-cycle flag window (apu_test 6); Phase 5"
 );
 blargg_test!(
     cpu_interrupts_all,
     "cpu_interrupts_v2/cpu_interrupts.nes",
     MEDIUM,
-    ignore = "fails in test 1 of 5 (APU frame IRQ never generated); Phase 3"
+    ignore =
+        "fails in test 3 of 5 (see cpu_interrupts_3_nmi_and_irq); 1, 2 and 4 pass individually; Phase 5"
 );
 
 // ---------------------------------------------------------------------
@@ -237,8 +235,7 @@ blargg_test!(
 blargg_test!(
     ppu_vbl_nmi_04_nmi_control,
     "ppu_vbl_nmi/rom_singles/04-nmi_control.nes",
-    SHORT,
-    ignore = "#11 Immediate occurence should be after NEXT instruction; Phase 3/4"
+    SHORT
 );
 blargg_test!(
     ppu_vbl_nmi_05_nmi_timing,


### PR DESCRIPTION
## Summary

Implements #10: the CPU now samples its NMI and IRQ inputs on the penultimate cycle of each instruction rather than reading the live state at the boundary.

- `tick` captures the inputs once per CPU cycle (after the PPU/APU advance, before the bus access): the PPU NMI edge is latched into `nmi_pending` with the tick it was first seen, the IRQ level goes into a per-tick bitmask.
- `cpu_step` takes a snapshot at the sample tick (`declared - 1`, or 1 for a taken non-page-crossing branch); `poll_interrupts` at the next boundary consumes the snapshot only.
- CLI/SEI/PLP poll with the old I flag (effect delayed one instruction); RTI is not delayed.
- BRK and the NMI/IRQ sequences do not poll at their end; an NMI edge visible by cycle 5 of BRK or the IRQ sequence hijacks the vector to `$FFFA`. The sequences now perform their dummy reads so all seven bus accesses happen in hardware order.
- Design rationale, the derivation of the model from the readme row counts, and the analysis of the remaining failures are in `docs/debugging/INTERRUPT_LINE.md` ("Sampling Point").

Files: `src/system.rs`, `src/system/tests.rs`, `tests/blargg.rs`, docs. No PPU, cartridge or APU changes, no new dependencies.

## Headless results

| Suite | Before | After |
|-------|--------|-------|
| cpu_interrupts_v2 1-cli_latency | Failed #4 | pass (un-ignored) |
| cpu_interrupts_v2 2-nmi_and_brk | wrong rows | pass (un-ignored) |
| cpu_interrupts_v2 3-nmi_and_irq | wrong rows | still ignored, see below |
| cpu_interrupts_v2 4-irq_and_dma | every offset one instruction early | pass (un-ignored) |
| cpu_interrupts_v2 5-branch_delays_irq | wrong PC column | still ignored, see below |
| cpu_interrupts_v2 combined | fails in test 1 | still ignored, fails in test 3 |
| ppu_vbl_nmi 04-nmi_control | Failed #11 | pass (un-ignored) |
| nestest (7 tests, 8991 lines: registers, CYC, PPU column) | pass | pass, unchanged |
| blargg total | 34 pass / 42 ignored | 38 pass / 38 ignored, no regressions |
| src/system unit tests | 9 | 15 (updated for the one-instruction latency; new tests for delayed CLI/SEI/PLP, penultimate vs last cycle, the branch rule, hijacking) |

Gates: `cargo build`, `cargo test` (debug), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all pass.

## Still ignored, with the observed failure

**3-nmi_and_irq**: output is the expected table shifted by one row (row 0 prints `21 00` where hardware prints `23 00`; three rows of `25 20` instead of two). The IRQ column is correct. The test syncs to vblank via a `$2002` loop and waits about two frames (59561.33 cycles) before the sequence, so the row alignment depends on the sub-cycle PPU/CPU phase and on the exact cycle the vblank flag becomes readable; test 2 uses the same sync with a one-frame wait and is exact. Root cause is on the PPU side (same territory as ppu_vbl_nmi 02/05-08), outside this lane.

**5-branch_delays_irq**: the PC column (which instruction the IRQ followed) matches the readme for `test_jmp`, and the branch special case is covered by a unit test. The CK column prints a constant `05`/`06`: the test's IRQ handler measures the IRQ phase against the APU frame flag with one-cycle resolution, which needs the exact 29830-cycle period and the 3-cycle flag window. That is the apu_test 6 defect in `src/apu/mod.rs`, outside this lane.

**Combined ROM**: stops at the first failing sub-test (3); it cannot pass until 3 and 5 do.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
