### PR TITLE
feat(ppu): per-dot sprite evaluation and fetch, exact sprite 0 hit and MMC3 A12 timing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Contains debugging session notes and references:
 - `BUS_TICK_TIMING.md` - PPU and APU advance inside each CPU bus access, DMA as real cycles (#4)
 - `VBLANK_NMI_TIMING.md` - NMI line withdrawal, 2002 suppression window, sample dot, odd-frame skip (#12)
 - `APU_FRAME_COUNTER.md` - frame sequencer schedule, three-cycle IRQ flag window, length counter enable/halt, power-up and reset state (#18)
+- `PPU_SPRITE_PIPELINE.md` - Per-dot sprite evaluation and fetch, overflow scan bug, sprite 0 hit rules, 8-pixel background shift fix, MMC3 A12 dot timing (#11)
 
 ### `/plans/`
 Contains implementation plans and roadmaps:

--- a/docs/debugging/PPU_CYCLE_ACCURATE_REFACTOR.md
+++ b/docs/debugging/PPU_CYCLE_ACCURATE_REFACTOR.md
@@ -673,6 +673,6 @@ Covered by five unit tests in the PPU tests module (`oam_*`).
 
 ### Remaining Limitation
 
-Known Limitations item 3 (batched sprite evaluation) still applies. Until it
-is replaced, `$2004` reads between cycles 65 and 340 of a rendering line do
-not track the evaluation pointer.
+Resolved by issue 11 (docs/debugging/PPU_SPRITE_PIPELINE.md): evaluation
+now runs per dot and `$2004` reads between cycles 65 and 320 return the byte
+the evaluation unit or the sprite fetch is looking at.

--- a/docs/debugging/PPU_SPRITE_PIPELINE.md
+++ b/docs/debugging/PPU_SPRITE_PIPELINE.md
@@ -1,0 +1,162 @@
+# Per-Dot Sprite Evaluation, Sprite Fetch Timing and Sprite 0 Hit
+
+**Date:** 2026-09-05
+**Type:** Accuracy Fix
+**Issue:** #11 (last item of Phase 5, docs/plans/ACCURACY_ROADMAP.md)
+**Status:** Complete
+
+## Executive Summary
+
+All eleven `sprite_hit_tests_2005.10.05` ROMs, all five `sprite_overflow_tests`
+ROMs and `mmc3_test_2` 4-scanline_timing pass. Sprite evaluation now runs one
+OAM access per dot over cycles 65-256 with the hardware's overflow-scan bug,
+the eight sprite fetches are spread over 257-320 at their exact dots, and the
+render units are separate from the evaluation state. Two background bugs came
+out along the way: the picture was drawn 8 pixels to the right of where the
+nametable puts it, and the PPU address bus was driven one dot late for the
+MMC3.
+
+## Background
+
+`src/ppu/mod.rs` used to evaluate all 64 sprites at cycle 65 and fetch all
+eight slots at cycle 257. Both wrote straight into the fields that
+`render_pixel` reads for the line being drawn, so from pixel 64 onward the
+current line was rendered against the *next* line's sprite count, sprite 0
+flag and secondary OAM (attributes were read live from secondary OAM, which
+had just been cleared to $FF, so sprites left of x = 64 got palette 3 and
+behind-background priority). Sprite X ranges were computed with `u8`
+wrap-around, which dropped any sprite at X >= 249. The overflow flag was set
+only when sprites were enabled, not when the background alone was.
+
+## Changes Made (src/ppu/mod.rs)
+
+### 1. Evaluation unit, cycles 65-256
+
+`evaluate_sprites_cycle` follows the nesdev "PPU sprite evaluation" page:
+
+- Odd dots read `OAM[OAMADDR]` into `oam_copy_buffer`; even dots act on it.
+  n and m start from OAMADDR at dot 65 (so the entry at OAMADDR is sprite 0)
+  and are written back to OAMADDR after every even dot.
+- An in-range Y (`scanline >= y && scanline < y + height`, compared in u16
+  so Y = 239 is in range on line 239 and Y >= 240 never is) copies the four
+  bytes of the entry into secondary OAM, eight dots per sprite; a miss costs
+  two dots. The Y byte is written even on a miss (the next hit overwrites it).
+- Once eight sprites are found, writes turn into reads of secondary OAM and
+  the search continues with the hardware bug: a miss increments n *and* m
+  without carry, so the "Y" compared next is byte 1 of the following sprite,
+  then byte 2, byte 3 and byte 0 again (`sprite_overflow_tests` 4.Obscure).
+  A hit sets the overflow flag on that even dot and consumes three more
+  reads with m carrying into n; after that only n advances.
+- Evaluation runs whenever rendering is enabled (background or sprites) on
+  visible lines only. The pre-render line clears secondary OAM but does not
+  evaluate, so line 0 never shows sprites and the eight pre-render fetches
+  are all tile $FF.
+
+### 2. Sprite fetch slots, cycles 257-320
+
+`fetch_sprites_cycle`: slot i occupies dots 257+8i to 264+8i as two garbage
+nametable fetches (the nametable and attribute addresses the background
+pipeline would use), then pattern low and high. Data is read on the second
+dot of each pair and the *next* access's address is put on the bus at the
+end of that dot. Every slot fetches, empty ones included (secondary OAM is
+$FF, which yields tile $FF through the same address path). The render units
+(`sprite_patterns`, `sprite_positions`, `sprite_attributes`, `sprite_count`,
+`sprite_zero_in_units`) are loaded here and nowhere else, so the line being
+drawn is never disturbed. OAMADDR is held at 0 during 257-320.
+
+### 3. `$2004` reads during rendering
+
+Cycles 1-64 return $FF, 65-256 return the evaluation unit's copy buffer,
+257-320 return the secondary OAM byte the fetch is using (Y, tile, attribute,
+then X for the rest of the slot).
+
+### 4. Sprite 0 hit
+
+`render_pixel` already gated each layer on its enable bit and the left-8
+clip bits and excluded x = 255; those rules now see the right sprite data.
+The flag is set on the dot the pixel is emitted (cycle x + 1); tests 09, 10
+and 11 accept that. Priority does not matter, and only unit 0 with
+`sprite_zero_in_units` counts (sprite-on-sprite never hits).
+
+### 5. Background alignment: `increment_x` at 328 and 336
+
+The coarse-X increment was guarded with `cycle < 256`, which also skipped
+the prefetch tiles at 321-336. The prefetch therefore fetched tile 0 twice
+and the first fetch of the line fetched it a third time, drawing the whole
+picture 8 pixels right of the nametable. Every sprite_hit ROM with a single
+background tile (02, 03, 04, 08, 10) failed on its first check; the ones
+with a solid screen (01, 05, 06, 07) could not see it. The guard is gone;
+the increment at 256 is harmless because `copy_x` at 257 overwrites it.
+
+### 6. PPU address bus timing for the MMC3
+
+`mmc3_test_2` 4 measures the IRQ to the dot. Its constants say the counter
+is clocked at dot 260 with sprites at $1000 (`scanline_0_08 = 6976`), 256
+dots earlier with the background at $1000 (`scanline_0_10 = 6976 - 256`,
+i.e. dot 4, for the first line after vblank), and 21 dots earlier than that
+plus a line for later lines (`scanline_1_10 = scanline_0_10 - 21`, i.e. dot
+324 of the previous line). nesdev's MMC3 page states the same 260/324.
+Those are one dot before the wiki's first fetch dot (261, 5, 325): the PPU
+puts the next address on the bus at the end of the previous access. Both
+pipelines now do "read on the second dot, then drive the next address"
+(`background_pipeline_step`, `fetch_sprites_cycle`), and the dummy
+nametable fetches at 337-340 exist so A12 drops after the last prefetch.
+
+The 9-dot low run from 336 to 4 must *not* count (otherwise line 1's clock
+would land at dot 4 instead of 324), while the 68-dot sprite interval and
+vblank must, so `A12_FILTER_CYCLES` went from 8 to 10. `mmc3_test_2` 1, 2,
+3 and 5 still pass (their `$2006` toggles are at least 12 dots apart).
+
+### Debugging steps, in order
+
+1. Per-dot evaluation and fetch landed; ran the target ROMs. Overflow 1-5
+   and sprite_hit 01/05/06/07/09/11 passed; 02/03/04/08 failed on their first
+   check and 10 said "upper-left corner too late"; mmc3 4 reported code 3.
+2. Fetched the test sources (christopherpow/nes-test-roms mirror). 02 puts a
+   solid tile at $21F0 (x 128, y 120) and the sprite at (128, 119): full
+   overlap, no hit. 01 passes with a full solid screen. A whole-tile
+   horizontal offset was the only explanation; found the `cycle < 256` guard
+   on `increment_x`. Removing it fixed 02, 03, 04, 08 and 10.
+3. mmc3 4 code 3 ("scanline 0 IRQ should occur sooner when $2000=$08"): the
+   sprite pattern fetch at 261 was one dot late. Moving it to 260 passed
+   tests 2-7 and failed 9 (the $10 case).
+4. The `-256` and `-21` constants in the source fixed the $10 clocks at dot 4
+   (first line after vblank) and dot 324 (every later line). That needs the
+   A12 drop at 337 and a filter that rejects the 9-dot low run across the
+   line boundary: dummy fetches added, filter set to 10 dots. All 13 pass.
+5. Fingerprints changed for every commercial ROM because of the 8-pixel
+   shift; frames were dumped headlessly to PNG on main and on the branch
+   and compared (see Verification).
+
+## Verification
+
+- `sprite_hit_tests_2005.10.05` 01-11, `sprite_overflow_tests` 1-5 and
+  `mmc3_test_2` 1-5 pass (6 is the alternate MMC3 revision, exclusive with
+  5); all un-ignored in `tests/blargg.rs`.
+- No regression: `cargo test` in debug (live `debug_assert` on CPU bus
+  accesses), nestest all 7 checks, ppu_vbl_nmi all 11, oam_read,
+  oam_stress, ppu_open_bus.
+- Unit tests in the PPU tests module: evaluation cadence and `$2004`
+  visibility (`evaluation_reads_oam_on_odd_dots_and_copies_in_range_sprites`),
+  background-only evaluation and no evaluation on the pre-render line, the
+  overflow flag's write dot, the diagonal-scan bug, sprite 0 hit enable and
+  clip rules, and the A12 rise dots 260 and 324.
+- Commercial ROM fingerprints (`tests/game_frames.rs`) changed for every
+  title, as they must with an 8-pixel background shift. Frame dumps
+  compared by eye: SMB/Duck Hunt was a black screen on main (stuck waiting
+  for a sprite 0 hit that never came) and now shows its menu; Zelda's
+  select screen now draws the Link icons and heart cursor that were missing;
+  SMB3, Contra and TMNT title screens are identical apart from the shift;
+  Tetris' text was already garbled on main and is unchanged apart from the
+  shift (unrelated, worth its own issue).
+
+## Still open
+
+- Sprite 0 hit is set at cycle x + 1; nesdev says the image "acts as if it
+  starts at cycle 2". The blargg timing ROMs do not separate the two.
+- `$2003` writes during rendering still do not corrupt OAM, and evaluation
+  starting with OAMADDR & 3 != 0 follows Mesen's arithmetic but has no test
+  ROM coverage.
+- The A12 filter counts dots rather than M2 falling edges; 10 dots satisfies
+  every ROM we have but a game that toggles `$2006` at a 9-dot spacing would
+  differ.

--- a/docs/debugging/PPU_SPRITE_PIPELINE.md
+++ b/docs/debugging/PPU_SPRITE_PIPELINE.md
@@ -143,8 +143,8 @@ vblank must, so `A12_FILTER_CYCLES` went from 8 to 10. `mmc3_test_2` 1, 2,
   clip rules, and the A12 rise dots 260 and 324.
 - Commercial ROM fingerprints (`tests/game_frames.rs`) changed for every
   title, as they must with an 8-pixel background shift. Frame dumps
-  compared by eye: SMB/Duck Hunt was a black screen on main (stuck waiting
-  for a sprite 0 hit that never came) and now shows its menu; Zelda's
+  compared by eye: SMB/Duck Hunt was a black screen on main at every
+  checkpoint (cause not investigated) and now shows its menu; Zelda's
   select screen now draws the Link icons and heart cursor that were missing;
   SMB3, Contra and TMNT title screens are identical apart from the shift;
   Tetris' text was already garbled on main and is unchanged apart from the

--- a/docs/plans/ACCURACY_ROADMAP.md
+++ b/docs/plans/ACCURACY_ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-04
 **Type:** Architecture Plan
-**Status:** Phases 1-4 complete (2026-09-05); Phase 5 open
+**Status:** Phases 1-5 complete (2026-09-05); remaining: apu_test 1/5/6 and cpu_interrupts_v2 5 (APU frame counter timing)
 **Tracking:** GitHub issues #1 through #4 one per phase; Phase 5 is #11-#14; #10 is the interrupt-sampling follow-up
 
 ## Executive Summary
@@ -49,7 +49,7 @@ the compatibility bar for the commercial library.
 | Area | State | Problem |
 |------|-------|---------|
 | CPU | Inline `match` in `src/system.rs`, ~2200 lines, instruction-level timing | Returns a cycle count; PPU/APU catch up after the instruction |
-| PPU | `src/ppu/mod.rs`, shift-register pipeline (v0.1.0) | Owns its own copy of CHR; sprite eval/fetch batched at cycles 65 and 257 |
+| PPU | `src/ppu/mod.rs`, shift-register pipeline (v0.1.0) | Owns its own copy of CHR; sprite eval/fetch batched at cycles 65 and 257 (per-dot since #11) |
 | APU | `src/apu/mod.rs` | Stepped once per instruction, not per CPU cycle; no IRQ output |
 | Cartridge | Numeric `match` on mapper id in `src/cartridge/mod.rs` | MMC1, MMC3, MMC5, 65 in different styles; `mapper4.rs` unreferenced |
 | Interrupts | NMI polled after each instruction | No IRQ line, no edge/level semantics |
@@ -151,6 +151,8 @@ cycle.
 
 **Done when:** `sprite_hit_tests_2005.10.05`, `sprite_overflow_tests`,
 `ppu_open_bus`, `oam_read`, `oam_stress`, and all of `mmc3_test_2` pass.
+Met with #11 (2026-09-05, docs/debugging/PPU_SPRITE_PIPELINE.md); `mmc3_test_2`
+6 is the alternate MMC3 revision and is exclusive with 5 by design.
 
 ## Risks and Notes
 

--- a/docs/testing/TEST_ROM_HARNESS.md
+++ b/docs/testing/TEST_ROM_HARNESS.md
@@ -132,16 +132,16 @@ arms, so the unimplemented-opcode fallback was removed.
 | cpu_interrupts_v2 (5 + 1) | 6 | 0 | 1, 2 and 4 pass since issue 10, 3 since issue 12, 5 and the combined ROM since issue 18 (exact APU frame-flag period) |
 | ppu_vbl_nmi (10 + 1) | 11 | 0 | all pass since issue 12 (NMI line withdrawal, sample dot, odd-frame skip) |
 | ppu_open_bus | 1 | 0 | passes since issues 13 (decay latch) and 14 (attribute masking) |
-| sprite_hit_tests_2005.10.05 (11) | 1 | 10 | 11 passes since Phase 4; 01 #7, 02 #2, 03 #2, 04 #2, 05 #4, 06 #3, 07 #6, 08 #3; 09/10 hang |
-| sprite_overflow_tests (5) | 1 | 4 | 1 #7, 2 #9, 4 #7, 3 hangs; 5.Emulator passes |
+| sprite_hit_tests_2005.10.05 (11) | 11 | 0 | 11 since Phase 4; 01-10 since issue 11 (per-dot sprite pipeline, 8-pixel background shift fix) |
+| sprite_overflow_tests (5) | 5 | 0 | 5.Emulator since Phase 4; 1-4 since issue 11 |
 | apu_test (8 + 1) | 9 | 0 | 2, 3, 4, 7, 8 pass since the IRQ line landed (Phase 3); 1, 5, 6 and the combined ROM since issue 18 (nesdev sequencer schedule, length counter enable/halt) |
 | apu_reset (6) | 6 | 0 | all pass since issue 18 (power-up as a $4017 = $00 write, reset re-writes $4017 and keeps the triangle control flag); 4017_timing reports a delay of 8 |
 | oam_read | 1 | 0 | |
 | oam_stress | 1 | 0 | passes since attribute bits 2-4 are masked (issue 14) |
-| mmc3_test_2 (6) | 4 | 2 | 4 needs cycle-exact sprite fetch positions (Phase 5); 6 is the alternate revision, exclusive with 5 |
-| **Total blargg** | **60** | **16** | |
+| mmc3_test_2 (6) | 5 | 1 | 4 since issue 11 (address bus driven one dot ahead of each fetch, 10-dot A12 filter); 6 is the alternate revision, exclusive with 5 |
+| **Total blargg** | **75** | **1** | |
 
-Combined with nestest (7 tests): 67 integration tests pass, 16 are ignored,
+Combined with nestest (7 tests): 82 integration tests pass, 1 is ignored,
 plus the ignored game_frames fingerprint run.
 
 ### Expected progression
@@ -151,7 +151,7 @@ plus the ignored game_frames fingerprint run.
 | CPU fix for `$B4` (small, can ride with any phase) | instr_test-v5 05/official_only/all_instrs, nestest full register compare, likely `cpu_timing_test6` moves to a timing failure |
 | Phase 3 (IRQ line, NMI edge) | cpu_interrupts_v2, apu_reset (landed: apu_test 2/3/4/7/8 and mmc3_test_2 1/2/3/5 pass) |
 | Phase 4 (bus-tick timing) | landed: ppu_vbl_nmi 01/03 and sprite_hit 11 now pass |
-| Phase 5 (PPU cycle detail) | sprite_hit_tests, sprite_overflow_tests, mmc3_test_2 4; landed: oam_stress via issue 14, ppu_open_bus via issues 13 and 14, ppu_vbl_nmi and cpu_interrupts_v2 3 via issue 12, apu_test 1/5/6, apu_reset and cpu_interrupts_v2 5 via issue 18 |
+| Phase 5 (PPU cycle detail) | complete; landed: oam_stress via issue 14, ppu_open_bus via issues 13 and 14, ppu_vbl_nmi and cpu_interrupts_v2 3 via issue 12, apu_test 1/5/6, apu_reset and cpu_interrupts_v2 5 via issue 18, sprite_hit_tests, sprite_overflow_tests and mmc3_test_2 4 via issue 11 |
 | Interrupt sampling (issue 10) | landed: cpu_interrupts_v2 1/2/4 and ppu_vbl_nmi 04 now pass |
 
 ## Debug API reference (`src/system.rs`)

--- a/src/ppu/mod.rs
+++ b/src/ppu/mod.rs
@@ -1,8 +1,13 @@
 use crate::cartridge::{Mapper, Mirroring};
 use bitflags::bitflags;
 
-/// PPU cycles A12 must stay low before the next rising edge counts.
-const A12_FILTER_CYCLES: u16 = 8;
+/// PPU dots A12 must stay low before the next rising edge counts. Hardware
+/// wants "three falling edges of M2" (about nine dots); the shortest low run
+/// the rendering pipeline produces that must NOT count is the nine dots from
+/// the dummy nametable fetch at 337 to the first pattern fetch of the next
+/// line at dot 4 (mmc3_test_2 4, tests 10-13), while the 64-dot sprite
+/// interval and vblank must. See docs/debugging/PPU_SPRITE_PIPELINE.md.
+const A12_FILTER_CYCLES: u16 = 10;
 
 pub const SCREEN_WIDTH: usize = 256;
 pub const SCREEN_HEIGHT: usize = 240;
@@ -128,14 +133,37 @@ pub struct Ppu {
     bg_next_tile_lsb: u8,    // Next tile pattern low byte
     bg_next_tile_msb: u8,    // Next tile pattern high byte
 
-    // Sprite evaluation data
+    // Sprite evaluation unit (cycles 65-256, evaluates the NEXT line).
+    // See docs/debugging/PPU_SPRITE_PIPELINE.md.
     secondary_oam: [u8; 32],
+    /// Byte read from OAM on the last odd cycle; what `$2004` returns
+    /// while the evaluation unit owns the OAM bus.
+    oam_copy_buffer: u8,
+    /// Sprite index (n) and byte within the sprite (m) the evaluation unit
+    /// is looking at. OAMADDR is rewritten from these after every write
+    /// cycle so `$2004` reads track the evaluation.
+    eval_n: u8,
+    eval_m: u8,
+    /// Write pointer into secondary OAM (0-32; 32 means full).
+    eval_sec_addr: u8,
+    /// The sprite being examined was found in range (copy in progress).
+    eval_in_range: bool,
+    /// Evaluation has walked off the end of OAM (or finished the overflow
+    /// sprite); the remaining cycles only increment n.
+    eval_done: bool,
+    /// Reads left in the overflow sprite once the flag has been set.
+    eval_overflow_reads: u8,
+    /// The entry examined first this line is still the one being copied.
+    eval_first: bool,
+    /// The first entry examined (sprite 0) was copied to secondary OAM.
+    sprite_zero_next: bool,
+
+    // Sprite render units, loaded during cycles 257-320 for the next line.
     sprite_count: u8,
-    sprite_zero_in_secondary: bool,
+    sprite_zero_in_units: bool,
     sprite_patterns: [(u8, u8); 8],
     sprite_positions: [u8; 8],
-    sprite_priorities: [u8; 8],
-    sprite_indexes: [u8; 8],
+    sprite_attributes: [u8; 8],
 }
 
 impl Default for Ppu {
@@ -179,12 +207,20 @@ impl Ppu {
             bg_next_tile_lsb: 0,
             bg_next_tile_msb: 0,
             secondary_oam: [0xFF; 32],
+            oam_copy_buffer: 0xFF,
+            eval_n: 0,
+            eval_m: 0,
+            eval_sec_addr: 0,
+            eval_in_range: false,
+            eval_done: false,
+            eval_overflow_reads: 0,
+            eval_first: false,
+            sprite_zero_next: false,
             sprite_count: 0,
-            sprite_zero_in_secondary: false,
+            sprite_zero_in_units: false,
             sprite_patterns: [(0, 0); 8],
             sprite_positions: [0; 8],
-            sprite_priorities: [0; 8],
-            sprite_indexes: [0; 8],
+            sprite_attributes: [0; 8],
         };
 
         // Initialize with default NES palette values
@@ -336,16 +372,31 @@ impl Ppu {
     /// $2004 read. Never modifies OAMADDR.
     ///
     /// While rendering is active the PPU's sprite evaluation unit owns the
-    /// OAM bus, so the CPU sees whatever byte it is examining. During the
-    /// secondary OAM clear (cycles 1-64) that is always $FF. For the rest of
-    /// the line we return `oam_data[oam_addr]`; this is an approximation
-    /// until per-cycle sprite evaluation lands (issue 11), at which point the
-    /// read should follow the evaluation unit's own OAM pointer.
+    /// OAM bus, so the CPU sees whatever byte it is examining: $FF during
+    /// the secondary OAM clear (cycles 1-64), the byte last read from OAM
+    /// during evaluation (65-256), and the secondary OAM byte the sprite
+    /// fetch is using (257-320: Y, tile, attribute, then X for the rest of
+    /// the slot). Outside rendering the read returns `oam_data[oam_addr]`.
     fn read_oam_data(&self) -> u8 {
-        if self.is_rendering() && (1..=64).contains(&self.cycle) {
-            return 0xFF;
+        if !self.is_rendering() {
+            return self.oam_data[self.oam_addr as usize];
         }
-        self.oam_data[self.oam_addr as usize]
+        match self.cycle {
+            1..=64 => 0xFF,
+            257..=320 => {
+                let off = (self.cycle - 257) as usize;
+                self.secondary_oam[(off / 8) * 4 + (off % 8).min(3)]
+            }
+            _ => self.oam_copy_buffer,
+        }
+    }
+
+    fn sprite_height(&self) -> u8 {
+        if self.ctrl.contains(PpuCtrl::SPRITE_SIZE) {
+            16
+        } else {
+            8
+        }
     }
 
     fn read_ppu_data(&mut self, mapper: &mut dyn Mapper) -> u8 {
@@ -595,66 +646,12 @@ impl Ppu {
 
         if self.scanline < 240 {
             // Visible scanlines (0-239)
-            if self.cycle == 1 {
-                // Clear secondary OAM for sprite evaluation
-                for i in 0..32 {
-                    self.secondary_oam[i] = 0xFF;
-                }
-                self.sprite_count = 0;
-                self.sprite_zero_in_secondary = false;
-            }
-
-            // Sprite evaluation happens during cycles 65-256
-            if self.cycle == 65 && self.mask.contains(PpuMask::SHOW_SPRITES) {
-                self.evaluate_sprites();
-            }
-
-            // Sprite fetching happens during cycles 257-320. The hardware
-            // performs all eight fetches whenever rendering is enabled,
-            // using tile $FF for empty slots; those dummy fetches are what
-            // toggle A12 for the MMC3 scanline counter.
-            if self.cycle == 257 && rendering_enabled {
-                self.fetch_sprites(mapper);
-            }
-
-            // Background rendering with cycle-accurate tile fetching
             if rendering_enabled {
-                // Update shift registers every cycle during rendering
-                if (self.cycle >= 1 && self.cycle <= 256)
-                    || (self.cycle >= 321 && self.cycle <= 336)
-                {
-                    self.update_shifters();
+                self.sprite_pipeline_step(mapper);
+            }
 
-                    // 8-cycle tile fetch pipeline
-                    match (self.cycle - 1) % 8 {
-                        0 => {
-                            // Load previous tile data into shift registers
-                            self.load_background_shifters();
-                        }
-                        1 => {
-                            // Fetch nametable byte (tile ID)
-                            self.fetch_nametable_byte(mapper);
-                        }
-                        3 => {
-                            // Fetch attribute byte (palette)
-                            self.fetch_attribute_byte(mapper);
-                        }
-                        5 => {
-                            // Fetch pattern table low byte
-                            self.fetch_pattern_low(mapper);
-                        }
-                        7 => {
-                            // Fetch pattern table high byte
-                            self.fetch_pattern_high(mapper);
-
-                            // Increment coarse X after fetching a complete tile
-                            if self.cycle < 256 {
-                                self.increment_x();
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+            if rendering_enabled {
+                self.background_pipeline_step(mapper);
 
                 // Render pixel (output from shift registers)
                 if self.cycle >= 1 && self.cycle <= 256 {
@@ -694,42 +691,14 @@ impl Ppu {
 
             // Pre-render scanline updates
             if rendering_enabled {
-                // Sprite fetch slot (cycles 257-320) runs here too, with all
-                // eight slots empty; it is the 241st MMC3 clock of a frame.
-                if self.cycle == 257 {
-                    self.sprite_count = 0;
-                    self.fetch_sprites(mapper);
-                }
+                // The secondary OAM clear and the sprite fetch slots run
+                // here too, but no evaluation, so every slot is empty and
+                // line 0 never shows sprites. The eight dummy fetches are
+                // the 241st MMC3 clock of a frame.
+                self.sprite_pipeline_step(mapper);
                 // Run the same tile fetching pipeline as visible scanlines
                 // This primes the shift registers for the first scanline
-                if (self.cycle >= 1 && self.cycle <= 256)
-                    || (self.cycle >= 321 && self.cycle <= 336)
-                {
-                    self.update_shifters();
-
-                    // 8-cycle tile fetch pipeline
-                    match (self.cycle - 1) % 8 {
-                        0 => {
-                            self.load_background_shifters();
-                        }
-                        1 => {
-                            self.fetch_nametable_byte(mapper);
-                        }
-                        3 => {
-                            self.fetch_attribute_byte(mapper);
-                        }
-                        5 => {
-                            self.fetch_pattern_low(mapper);
-                        }
-                        7 => {
-                            self.fetch_pattern_high(mapper);
-                            if self.cycle < 256 {
-                                self.increment_x();
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+                self.background_pipeline_step(mapper);
 
                 // Increment Y at end of scanline
                 if self.cycle == 256 {
@@ -765,6 +734,69 @@ impl Ppu {
         }
     }
 
+    /// One dot of the background fetch pipeline on a line with rendering
+    /// enabled. Every access takes two dots: the data is read on the second
+    /// and the address of the next access is put on the bus at the end of
+    /// that same dot, which is why the MMC3 sees the first pattern fetch of
+    /// a tile at dots 4, 12, ... (and 324 for the prefetch) rather than 5.
+    /// Dots 337-340 perform the two dummy nametable fetches.
+    fn background_pipeline_step(&mut self, mapper: &mut dyn Mapper) {
+        if (self.cycle >= 1 && self.cycle <= 256) || (self.cycle >= 321 && self.cycle <= 336) {
+            self.update_shifters();
+
+            match (self.cycle - 1) % 8 {
+                0 => self.load_background_shifters(),
+                1 => {
+                    self.fetch_nametable_byte(mapper);
+                    self.drive_addr_bus(self.bg_fetch_addr(1), mapper);
+                }
+                3 => {
+                    self.fetch_attribute_byte(mapper);
+                    self.drive_addr_bus(self.bg_fetch_addr(2), mapper);
+                }
+                5 => {
+                    self.fetch_pattern_low(mapper);
+                    self.drive_addr_bus(self.bg_fetch_addr(3), mapper);
+                }
+                7 => {
+                    self.fetch_pattern_high(mapper);
+                    // Increment coarse X after every tile, at 256 and at
+                    // 328/336 too (that is what puts tile 1 after tile 0
+                    // on the next line; skipping it shifts the picture by
+                    // 8 pixels), then put the next nametable address on
+                    // the bus.
+                    self.increment_x();
+                    self.drive_addr_bus(self.bg_fetch_addr(0), mapper);
+                }
+                _ => {}
+            }
+        } else if self.cycle == 338 || self.cycle == 340 {
+            let addr = self.bg_fetch_addr(0);
+            self.read_vram(addr, mapper);
+        }
+    }
+
+    /// Address of background access `phase` for the tile at `v`: 0 the
+    /// nametable byte, 1 the attribute byte, 2 and 3 the pattern low and
+    /// high bytes (using the tile id latched by the nametable fetch).
+    fn bg_fetch_addr(&self, phase: u8) -> u16 {
+        let v = self.v;
+        match phase {
+            0 => 0x2000 | (v & 0x0FFF),
+            1 => 0x23C0 | (v & 0x0C00) | ((v >> 4) & 0x38) | ((v >> 2) & 0x07),
+            _ => {
+                let pattern_table = if self.ctrl.contains(PpuCtrl::BG_PATTERN) {
+                    0x1000
+                } else {
+                    0x0000
+                };
+                let fine_y = (v >> 12) & 0x07;
+                let plane = if phase == 3 { 8 } else { 0 };
+                pattern_table + (self.bg_next_tile_id as u16 * 16) + fine_y + plane
+            }
+        }
+    }
+
     fn render_pixel(&mut self) {
         let x = (self.cycle - 1) as usize;
         let y = self.scanline as usize;
@@ -790,7 +822,7 @@ impl Ppu {
             if self.mask.contains(PpuMask::SHOW_SPRITES)
                 && (x >= 8 || self.mask.contains(PpuMask::SHOW_SPRITES_LEFT))
             {
-                let sprite_data = self.get_sprite_pixel(x as u8);
+                let sprite_data = self.get_sprite_pixel(x as u16);
                 if sprite_data.0 > 0 {
                     sprite_pixel = sprite_data.0 & 0x03;
                     sprite_palette = (sprite_data.0 >> 2) & 0x03;
@@ -874,54 +906,32 @@ impl Ppu {
         self.v = (self.v & !0x7BE0) | (self.t & 0x7BE0);
     }
 
-    // Tile fetch pipeline functions
+    // Tile fetch pipeline functions (each is the read half of an access;
+    // see `background_pipeline_step` for the bus timing)
     fn fetch_nametable_byte(&mut self, mapper: &mut dyn Mapper) {
-        // Fetch tile ID from nametable
-        // Nametable address: 0x2000 | (v & 0x0FFF)
-        let addr = 0x2000 | (self.v & 0x0FFF);
+        let addr = self.bg_fetch_addr(0);
         self.bg_next_tile_id = self.read_vram(addr, mapper);
     }
 
     fn fetch_attribute_byte(&mut self, mapper: &mut dyn Mapper) {
-        // Fetch attribute byte from attribute table
-        // Attribute address: 0x23C0 | (v & 0x0C00) | ((v >> 4) & 0x38) | ((v >> 2) & 0x07)
         let v = self.v;
-        let addr = 0x23C0 | (v & 0x0C00) | ((v >> 4) & 0x38) | ((v >> 2) & 0x07);
+        let addr = self.bg_fetch_addr(1);
         let attribute = self.read_vram(addr, mapper);
 
-        // Determine which 2 bits of the attribute byte to use
-        // based on the 2x2 tile position within the 4x4 tile group
+        // Pick the 2 bits for this tile's 2x2 quadrant of the 4x4 group.
         let coarse_x = v & 0x001F;
         let coarse_y = (v >> 5) & 0x001F;
         let shift = ((coarse_y & 0x02) << 1) | (coarse_x & 0x02);
-
-        // Extract the 2-bit palette value
         self.bg_next_tile_attrib = (attribute >> shift) & 0x03;
     }
 
     fn fetch_pattern_low(&mut self, mapper: &mut dyn Mapper) {
-        // Fetch low pattern byte from pattern table
-        // Pattern table address: (ctrl.bg_pattern * 0x1000) + (tile_id * 16) + fine_y
-        let pattern_table = if self.ctrl.contains(PpuCtrl::BG_PATTERN) {
-            0x1000
-        } else {
-            0x0000
-        };
-        let fine_y = (self.v >> 12) & 0x07;
-        let addr = pattern_table + (self.bg_next_tile_id as u16 * 16) + fine_y;
+        let addr = self.bg_fetch_addr(2);
         self.bg_next_tile_lsb = self.read_vram(addr, mapper);
     }
 
     fn fetch_pattern_high(&mut self, mapper: &mut dyn Mapper) {
-        // Fetch high pattern byte from pattern table
-        // Pattern table address: (ctrl.bg_pattern * 0x1000) + (tile_id * 16) + fine_y + 8
-        let pattern_table = if self.ctrl.contains(PpuCtrl::BG_PATTERN) {
-            0x1000
-        } else {
-            0x0000
-        };
-        let fine_y = (self.v >> 12) & 0x07;
-        let addr = pattern_table + (self.bg_next_tile_id as u16 * 16) + fine_y + 8;
+        let addr = self.bg_fetch_addr(3);
         self.bg_next_tile_msb = self.read_vram(addr, mapper);
     }
 
@@ -1004,155 +1014,237 @@ impl Ppu {
         &self.frame_buffer
     }
 
-    fn evaluate_sprites(&mut self) {
-        let mut secondary_index = 0;
-        self.sprite_count = 0;
-        self.sprite_zero_in_secondary = false;
-
-        let sprite_height = if self.ctrl.contains(PpuCtrl::SPRITE_SIZE) {
-            16
-        } else {
-            8
-        };
-        // Sprites are evaluated for the NEXT scanline
-        let y = (self.scanline + 1) as i16;
-
-        // Evaluate all 64 sprites
-        for sprite_index in 0..64 {
-            if secondary_index >= 32 {
-                // Secondary OAM is full, set overflow flag
-                self.status.insert(PpuStatus::SPRITE_OVERFLOW);
-                break;
+    /// One dot of the sprite pipeline on a visible or pre-render line with
+    /// rendering enabled. Hardware timing (nesdev "PPU sprite evaluation"):
+    ///
+    /// * 1-64: secondary OAM is cleared to $FF.
+    /// * 65-256: OAM is read on odd dots and secondary OAM written on even
+    ///   dots, evaluating the next line's sprites (visible lines only).
+    /// * 257-320: eight fetch slots of eight dots each load the render
+    ///   units; OAMADDR is held at 0.
+    fn sprite_pipeline_step(&mut self, mapper: &mut dyn Mapper) {
+        match self.cycle {
+            1 => {
+                self.secondary_oam = [0xFF; 32];
+                self.oam_copy_buffer = 0xFF;
+                self.eval_sec_addr = 0;
+                self.sprite_zero_next = false;
             }
-
-            let oam_offset = sprite_index * 4;
-            let sprite_y = self.oam_data[oam_offset] as i16 + 1; // Sprites are delayed by one scanline
-
-            // Check if sprite is on the next scanline
-            if y >= sprite_y && y < sprite_y + sprite_height {
-                // Copy sprite to secondary OAM
-                if secondary_index < 32 {
-                    for i in 0..4 {
-                        self.secondary_oam[secondary_index + i] = self.oam_data[oam_offset + i];
-                    }
-
-                    if sprite_index == 0 {
-                        self.sprite_zero_in_secondary = true;
-                    }
-
-                    if self.sprite_count < 8 {
-                        self.sprite_indexes[self.sprite_count as usize] = sprite_index as u8;
-                    }
-                    self.sprite_count += 1;
-                    secondary_index += 4;
-                }
+            65..=256 if self.scanline < 240 => self.evaluate_sprites_cycle(),
+            257..=320 => {
+                self.oam_addr = 0;
+                self.fetch_sprites_cycle(mapper);
             }
+            _ => {}
         }
     }
 
-    fn fetch_sprites(&mut self, mapper: &mut dyn Mapper) {
-        let sprite_height = if self.ctrl.contains(PpuCtrl::SPRITE_SIZE) {
-            16
-        } else {
-            8
-        };
+    /// One dot of sprite evaluation (cycles 65-256).
+    ///
+    /// Odd dots read `OAM[n][m]` into the copy buffer; even dots act on it.
+    /// While fewer than eight sprites have been found, an in-range Y copies
+    /// the four bytes of the entry into secondary OAM (eight dots per
+    /// sprite), otherwise n advances (two dots per sprite). Once secondary
+    /// OAM is full the search continues with the hardware bug: a miss
+    /// increments both n and m, so the byte compared as Y walks diagonally
+    /// through OAM; a hit sets the overflow flag and consumes three more
+    /// reads, after which evaluation is done. n and m are written back to
+    /// OAMADDR after every even dot, which is why `$2004` reads follow it.
+    fn evaluate_sprites_cycle(&mut self) {
+        if self.cycle == 65 {
+            self.eval_n = self.oam_addr >> 2;
+            self.eval_m = self.oam_addr & 0x03;
+            self.eval_sec_addr = 0;
+            self.eval_in_range = false;
+            self.eval_done = false;
+            self.eval_overflow_reads = 0;
+            self.eval_first = true;
+            self.sprite_zero_next = false;
+        }
 
-        let sprite_count = self.sprite_count.min(8);
-        for i in 0..8u8 {
-            if i >= sprite_count {
-                // Empty slot: the hardware still fetches tile $FF from the
-                // sprite pattern table (always $1000 in 8x16 mode).
-                let base = if sprite_height == 16 || self.ctrl.contains(PpuCtrl::SPRITE_PATTERN) {
-                    0x1000
+        if self.cycle & 1 == 1 {
+            self.oam_copy_buffer = self.oam_data[self.oam_addr as usize];
+            return;
+        }
+
+        if self.eval_done {
+            // Keep walking n; with secondary OAM full the "write" turns
+            // into a read of secondary OAM.
+            self.eval_n = (self.eval_n + 1) & 0x3F;
+            if self.eval_sec_addr >= 32 {
+                self.oam_copy_buffer = self.secondary_oam[(self.eval_sec_addr & 0x1F) as usize];
+            }
+        } else {
+            let y = self.oam_copy_buffer as u16;
+            let height = self.sprite_height() as u16;
+            if !self.eval_in_range && self.scanline >= y && self.scanline < y + height {
+                self.eval_in_range = true;
+            }
+
+            if self.eval_sec_addr < 32 {
+                self.secondary_oam[self.eval_sec_addr as usize] = self.oam_copy_buffer;
+                if self.eval_in_range {
+                    self.eval_m = self.eval_m.wrapping_add(1);
+                    self.eval_sec_addr += 1;
+                    if self.eval_first {
+                        self.sprite_zero_next = true;
+                    }
+                    if self.eval_sec_addr & 0x03 == 0 {
+                        // All four bytes copied; on to the next entry.
+                        self.eval_in_range = false;
+                        self.eval_m = 0;
+                        self.eval_first = false;
+                        self.advance_eval_n();
+                    }
                 } else {
-                    0x0000
-                };
-                let dummy = base | 0x0FF0;
-                self.drive_addr_bus(dummy, mapper);
-                self.drive_addr_bus(dummy + 8, mapper);
+                    self.eval_first = false;
+                    self.advance_eval_n();
+                }
+            } else {
+                self.oam_copy_buffer = self.secondary_oam[(self.eval_sec_addr & 0x1F) as usize];
+                if self.eval_in_range {
+                    // Ninth sprite found: flag it and read out its
+                    // remaining bytes with m carrying into n.
+                    self.status.insert(PpuStatus::SPRITE_OVERFLOW);
+                    self.eval_m += 1;
+                    if self.eval_m == 4 {
+                        self.eval_m = 0;
+                        self.eval_n = (self.eval_n + 1) & 0x3F;
+                    }
+                    if self.eval_overflow_reads == 0 {
+                        self.eval_overflow_reads = 3;
+                    } else {
+                        self.eval_overflow_reads -= 1;
+                        if self.eval_overflow_reads == 0 {
+                            self.eval_done = true;
+                            self.eval_m = 0;
+                        }
+                    }
+                } else {
+                    // The hardware bug: n and m advance together, without
+                    // carry, so the next "Y" comes from a different byte.
+                    self.eval_n = (self.eval_n + 1) & 0x3F;
+                    self.eval_m = (self.eval_m + 1) & 0x03;
+                    if self.eval_n == 0 {
+                        self.eval_done = true;
+                    }
+                }
+            }
+        }
+
+        self.oam_addr = (self.eval_n << 2) | (self.eval_m & 0x03);
+    }
+
+    fn advance_eval_n(&mut self) {
+        self.eval_n = (self.eval_n + 1) & 0x3F;
+        if self.eval_n == 0 {
+            self.eval_done = true;
+        }
+    }
+
+    /// One dot of the sprite fetch interval (cycles 257-320). Slot i covers
+    /// dots 257+8i to 264+8i: two garbage nametable fetches (the addresses
+    /// the background pipeline would use), then the pattern low and high
+    /// bytes, each read on the second dot of its pair with the next address
+    /// driven at the end of that dot. Every slot fetches, even an empty one
+    /// (tile $FF from the $FF-filled secondary OAM); the A12 rise for the
+    /// first pattern fetch, at dot 260, is what clocks the MMC3 once per
+    /// line when sprites use $1000.
+    fn fetch_sprites_cycle(&mut self, mapper: &mut dyn Mapper) {
+        let off = self.cycle - 257;
+        let slot = (off / 8) as usize;
+        match off % 8 {
+            0 => {
+                if slot == 0 {
+                    // The units for the next line are loaded from here on;
+                    // the current line's pixels are all out already.
+                    self.sprite_count = (self.eval_sec_addr >> 2).min(8);
+                    self.sprite_zero_in_units = self.sprite_zero_next;
+                }
+            }
+            1 => {
+                let addr = self.bg_fetch_addr(0);
+                self.read_vram(addr, mapper);
+                self.drive_addr_bus(self.bg_fetch_addr(1), mapper);
+            }
+            3 => {
+                let addr = self.bg_fetch_addr(1);
+                self.read_vram(addr, mapper);
+                // Dot 260 + 8 * slot: the MMC3 clock when sprites use $1000.
+                self.drive_addr_bus(self.sprite_pattern_addr(slot), mapper);
+            }
+            5 => {
+                let addr = self.sprite_pattern_addr(slot);
+                let low = self.read_vram(addr, mapper);
+                self.sprite_patterns[slot].0 = low;
+                self.drive_addr_bus(addr + 8, mapper);
+            }
+            7 => {
+                let addr = self.sprite_pattern_addr(slot) + 8;
+                let high = self.read_vram(addr, mapper);
+                let attributes = self.secondary_oam[slot * 4 + 2];
+                let (mut low, mut high) = (self.sprite_patterns[slot].0, high);
+                if attributes & 0x40 != 0 {
+                    low = reverse_byte(low);
+                    high = reverse_byte(high);
+                }
+                self.sprite_patterns[slot] = (low, high);
+                self.sprite_positions[slot] = self.secondary_oam[slot * 4 + 3];
+                self.sprite_attributes[slot] = attributes;
+                // Next slot's garbage nametable fetch, or at 320 the
+                // background prefetch; either way A12 drops.
+                self.drive_addr_bus(self.bg_fetch_addr(0), mapper);
+            }
+            _ => {}
+        }
+    }
+
+    /// Pattern address of the row of secondary OAM sprite `slot` that the
+    /// next line needs. Rows are masked to the sprite height, so an empty
+    /// slot (Y = $FF, tile $FF, attributes $FF) yields a valid tile $FF
+    /// address; the pre-render line uses the same path.
+    fn sprite_pattern_addr(&self, slot: usize) -> u16 {
+        let y = self.secondary_oam[slot * 4];
+        let tile = self.secondary_oam[slot * 4 + 1];
+        let attributes = self.secondary_oam[slot * 4 + 2];
+        let height = self.sprite_height();
+        // Evaluated on line N for line N+1; sprites appear at Y+1.
+        let mut row = (self.scanline as u8).wrapping_sub(y) & (height - 1);
+        if attributes & 0x80 != 0 {
+            row = (height - 1) - row;
+        }
+        if height == 8 {
+            let base = if self.ctrl.contains(PpuCtrl::SPRITE_PATTERN) {
+                0x1000
+            } else {
+                0x0000
+            };
+            base | (tile as u16) << 4 | row as u16
+        } else {
+            let bank = (tile as u16 & 1) << 12;
+            let tile = (tile & 0xFE) as u16 + if row >= 8 { 1 } else { 0 };
+            bank | tile << 4 | (row & 7) as u16
+        }
+    }
+
+    /// Output of the sprite units for pixel `x`: (palette index, behind
+    /// background, is sprite 0). The lowest-numbered unit with an opaque
+    /// pixel wins.
+    fn get_sprite_pixel(&self, x: u16) -> (u8, bool, bool) {
+        for i in 0..self.sprite_count.min(8) as usize {
+            let sprite_x = self.sprite_positions[i] as u16;
+            if x < sprite_x || x >= sprite_x + 8 {
                 continue;
             }
-            let oam_offset = i as usize * 4;
-            let y_pos = self.secondary_oam[oam_offset];
-            let tile_index = self.secondary_oam[oam_offset + 1];
-            let attributes = self.secondary_oam[oam_offset + 2];
-            let x_pos = self.secondary_oam[oam_offset + 3];
-
-            // Calculate the line of the sprite to fetch (sprites fetched are for the next scanline)
-            let sprite_y = (self.scanline + 1).wrapping_sub(y_pos as u16 + 1);
-
-            // Handle vertical flip
-            let actual_y = if (attributes & 0x80) != 0 {
-                // Vertically flipped
-                (sprite_height - 1) - sprite_y
-            } else {
-                sprite_y
-            };
-
-            // Determine pattern table address
-            let pattern_addr = if sprite_height == 8 {
-                // 8x8 sprites
-                let base = if self.ctrl.contains(PpuCtrl::SPRITE_PATTERN) {
-                    0x1000
-                } else {
-                    0x0000
-                };
-                base + (tile_index as u16 * 16) + (actual_y & 7)
-            } else {
-                // 8x16 sprites
-                let bank = (tile_index & 1) as u16 * 0x1000;
-                let tile = (tile_index & 0xFE) as u16;
-                let offset = if actual_y >= 8 {
-                    actual_y - 8 + 16
-                } else {
-                    actual_y
-                };
-                bank + (tile * 16) + offset
-            };
-
-            // Fetch pattern data
-            let low_byte = self.read_vram(pattern_addr & 0x1FFF, mapper);
-            let high_byte = self.read_vram((pattern_addr + 8) & 0x1FFF, mapper);
-
-            // Handle horizontal flip
-            let (low, high) = if (attributes & 0x40) != 0 {
-                // Horizontally flipped
-                (reverse_byte(low_byte), reverse_byte(high_byte))
-            } else {
-                (low_byte, high_byte)
-            };
-
-            self.sprite_patterns[i as usize] = (low, high);
-            self.sprite_positions[i as usize] = x_pos;
-            self.sprite_priorities[i as usize] = attributes & 0x20;
-        }
-    }
-
-    fn get_sprite_pixel(&self, x: u8) -> (u8, bool, bool) {
-        if self.sprite_count == 0 {
-            return (0, false, false);
-        }
-
-        for i in 0..self.sprite_count.min(8) {
-            let sprite_x = self.sprite_positions[i as usize];
-
-            if x >= sprite_x && x < sprite_x.wrapping_add(8) {
-                let pixel_x = x.wrapping_sub(sprite_x);
-                let (low, high) = self.sprite_patterns[i as usize];
-
-                let bit = 7 - pixel_x;
-                let pixel_value = ((high >> bit) & 1) << 1 | ((low >> bit) & 1);
-
-                if pixel_value != 0 {
-                    // Get palette from attributes
-                    let oam_index = (i as usize * 4 + 2).min(31);
-                    let attributes = self.secondary_oam[oam_index];
-                    let palette = (attributes & 0x03) + 4; // Sprite palettes are 4-7
-                    let priority = (attributes & 0x20) != 0;
-                    let is_sprite_zero = i == 0 && self.sprite_zero_in_secondary;
-
-                    return ((palette << 2) | pixel_value, priority, is_sprite_zero);
-                }
+            let bit = 7 - (x - sprite_x);
+            let (low, high) = self.sprite_patterns[i];
+            let pixel_value = ((high >> bit) & 1) << 1 | ((low >> bit) & 1);
+            if pixel_value != 0 {
+                let attributes = self.sprite_attributes[i];
+                let palette = (attributes & 0x03) + 4; // Sprite palettes are 4-7
+                let priority = (attributes & 0x20) != 0;
+                let is_sprite_zero = i == 0 && self.sprite_zero_in_units;
+                return ((palette << 2) | pixel_value, priority, is_sprite_zero);
             }
         }
 
@@ -1407,14 +1499,13 @@ mod tests {
             );
         }
 
-        ppu.scanline = 100;
-        ppu.cycle = 65;
-        assert_eq!(oam_read(&mut ppu, 0x05), 0x37, "after the clear window");
-        ppu.cycle = 0;
-        assert_eq!(oam_read(&mut ppu, 0x05), 0x37, "idle cycle 0");
         ppu.scanline = 241;
         ppu.cycle = 32;
         assert_eq!(oam_read(&mut ppu, 0x05), 0x37, "vblank");
+        ppu.scanline = 100;
+        ppu.cycle = 32;
+        ppu.mask = PpuMask::empty();
+        assert_eq!(oam_read(&mut ppu, 0x05), 0x37, "rendering off");
     }
 
     #[test]
@@ -1525,5 +1616,287 @@ mod tests {
         assert_eq!(ppu.read_register(0x2001, m.as_mut()), 0x20);
         ppu.frame += IO_BUS_DECAY_FRAMES + 1;
         assert_eq!(ppu.read_register(0x2001, m.as_mut()), 0x00);
+    }
+
+    // -----------------------------------------------------------------
+    // Sprite pipeline (issue 11): evaluation cadence, overflow bug,
+    // sprite 0 hit clipping
+    // -----------------------------------------------------------------
+
+    /// A PPU parked at the end of the secondary OAM clear on `scanline`,
+    /// with background rendering on so the pipeline runs.
+    fn eval_ppu(scanline: u16) -> Ppu {
+        let mut ppu = Ppu::new();
+        ppu.mask = PpuMask::SHOW_BG;
+        ppu.scanline = scanline;
+        ppu.cycle = 64;
+        ppu.secondary_oam = [0xFF; 32];
+        ppu
+    }
+
+    fn set_sprite(ppu: &mut Ppu, index: usize, y: u8, tile: u8, attr: u8, x: u8) {
+        ppu.oam_data[index * 4..index * 4 + 4].copy_from_slice(&[y, tile, attr, x]);
+    }
+
+    /// Step until `cycle` has just been processed.
+    fn step_to(ppu: &mut Ppu, m: &mut dyn Mapper, cycle: u16) {
+        while ppu.cycle < cycle {
+            ppu.step(m);
+        }
+    }
+
+    #[test]
+    fn evaluation_reads_oam_on_odd_dots_and_copies_in_range_sprites() {
+        let mut ppu = eval_ppu(10);
+        let mut m = nrom();
+        set_sprite(&mut ppu, 0, 10, 0x11, 0x01, 0x40); // rows 11-18: in range
+        set_sprite(&mut ppu, 1, 100, 0x22, 0x02, 0x50); // out of range
+        set_sprite(&mut ppu, 2, 5, 0x33, 0x03, 0x60); // rows 6-13: in range
+        for i in 3..64 {
+            set_sprite(&mut ppu, i, 0xF0, 0, 0, 0);
+        }
+
+        // 65: read sprite 0 Y; visible through $2004.
+        step_to(&mut ppu, m.as_mut(), 65);
+        assert_eq!(ppu.oam_copy_buffer, 10);
+        assert_eq!(ppu.read_register(0x2004, m.as_mut()), 10);
+        assert_eq!(ppu.oam_addr, 0, "OAMADDR moves on the write dot");
+        // 66: write it to secondary OAM, m advances.
+        step_to(&mut ppu, m.as_mut(), 66);
+        assert_eq!(ppu.secondary_oam[0], 10);
+        assert_eq!(ppu.oam_addr, 1);
+        // 72: four bytes copied, on to sprite 1.
+        step_to(&mut ppu, m.as_mut(), 72);
+        assert_eq!(&ppu.secondary_oam[0..4], &[10, 0x11, 0x01, 0x40]);
+        assert_eq!(ppu.oam_addr, 4);
+        assert!(ppu.sprite_zero_next);
+        // 73/74: sprite 1 is out of range, two dots and n advances.
+        step_to(&mut ppu, m.as_mut(), 73);
+        assert_eq!(ppu.read_register(0x2004, m.as_mut()), 100);
+        step_to(&mut ppu, m.as_mut(), 74);
+        assert_eq!(ppu.oam_addr, 8);
+        assert_eq!(ppu.secondary_oam[4], 100, "Y is written even on a miss");
+        // 82: sprite 2 copied into slot 1 (overwriting the miss).
+        step_to(&mut ppu, m.as_mut(), 82);
+        assert_eq!(&ppu.secondary_oam[4..8], &[5, 0x33, 0x03, 0x60]);
+        assert_eq!(ppu.oam_addr, 12);
+
+        step_to(&mut ppu, m.as_mut(), 256);
+        assert_eq!(ppu.eval_sec_addr, 8);
+        assert!(!ppu.status.contains(PpuStatus::SPRITE_OVERFLOW));
+
+        // 257: units latch and OAMADDR is held at 0 through the fetches;
+        // $2004 shows the secondary OAM byte the fetch is using.
+        ppu.oam_addr = 0x55;
+        step_to(&mut ppu, m.as_mut(), 257);
+        assert_eq!(ppu.oam_addr, 0);
+        assert_eq!(ppu.sprite_count, 2);
+        assert!(ppu.sprite_zero_in_units);
+        assert_eq!(ppu.read_register(0x2004, m.as_mut()), 10);
+        step_to(&mut ppu, m.as_mut(), 266);
+        assert_eq!(ppu.read_register(0x2004, m.as_mut()), 0x33);
+        step_to(&mut ppu, m.as_mut(), 268);
+        assert_eq!(ppu.read_register(0x2004, m.as_mut()), 0x60);
+        step_to(&mut ppu, m.as_mut(), 320);
+        assert_eq!(ppu.sprite_positions[1], 0x60);
+        assert_eq!(ppu.sprite_attributes[1], 0x03);
+    }
+
+    #[test]
+    fn evaluation_runs_with_background_only_and_not_on_pre_render_line() {
+        let mut ppu = eval_ppu(20);
+        let mut m = nrom();
+        for i in 0..9 {
+            set_sprite(&mut ppu, i, 20, 0, 0, 0);
+        }
+        step_to(&mut ppu, m.as_mut(), 256);
+        assert!(ppu.status.contains(PpuStatus::SPRITE_OVERFLOW));
+
+        let mut ppu = eval_ppu(261);
+        for i in 0..9 {
+            set_sprite(&mut ppu, i, 5, 0, 0, 0);
+        }
+        step_to(&mut ppu, m.as_mut(), 320);
+        assert!(!ppu.status.contains(PpuStatus::SPRITE_OVERFLOW));
+        assert_eq!(ppu.sprite_count, 0);
+        assert_eq!(ppu.oam_addr, 0);
+    }
+
+    #[test]
+    fn ninth_sprite_sets_overflow_on_its_write_dot() {
+        let mut ppu = eval_ppu(30);
+        let mut m = nrom();
+        for i in 0..9 {
+            set_sprite(&mut ppu, i, 30, 0, 0, 0);
+        }
+        // Sprites 0-7 take dots 65-128; sprite 8's Y is read at 129.
+        step_to(&mut ppu, m.as_mut(), 129);
+        assert!(!ppu.status.contains(PpuStatus::SPRITE_OVERFLOW));
+        step_to(&mut ppu, m.as_mut(), 130);
+        assert!(ppu.status.contains(PpuStatus::SPRITE_OVERFLOW));
+        // Its remaining three bytes are read with m carrying into n, then
+        // evaluation only walks n.
+        step_to(&mut ppu, m.as_mut(), 136);
+        assert!(ppu.eval_done);
+        assert_eq!(ppu.oam_addr, 9 << 2);
+    }
+
+    #[test]
+    fn overflow_scan_bug_reads_the_wrong_byte_as_y() {
+        // Eight sprites in range, the ninth not: the scan then compares
+        // byte 1 of sprite 9, byte 2 of sprite 10, ... as Y coordinates.
+        let mut m = nrom();
+        let mut ppu = eval_ppu(30);
+        for i in 0..8 {
+            set_sprite(&mut ppu, i, 30, 0, 0, 0);
+        }
+        for i in 8..64 {
+            set_sprite(&mut ppu, i, 200, 200, 0xE0, 200);
+        }
+        set_sprite(&mut ppu, 9, 200, 30, 0xE0, 200); // tile byte in range
+        step_to(&mut ppu, m.as_mut(), 131);
+        assert_eq!(ppu.read_register(0x2004, m.as_mut()), 30, "reads OAM[9][1]");
+        step_to(&mut ppu, m.as_mut(), 132);
+        assert!(ppu.status.contains(PpuStatus::SPRITE_OVERFLOW));
+
+        // Same layout but byte 1 of sprite 9 out of range and byte 3 of
+        // sprite 11 in range (X = 30): still flagged.
+        let mut ppu = eval_ppu(30);
+        for i in 0..8 {
+            set_sprite(&mut ppu, i, 30, 0, 0, 0);
+        }
+        for i in 8..64 {
+            set_sprite(&mut ppu, i, 200, 200, 0xE0, 200);
+        }
+        set_sprite(&mut ppu, 11, 200, 200, 0xE0, 30);
+        step_to(&mut ppu, m.as_mut(), 256);
+        assert!(ppu.status.contains(PpuStatus::SPRITE_OVERFLOW));
+
+        // And with every wrongly-read byte out of range: no flag, even
+        // though sprite 13's real Y is in range (the scan reads its tile
+        // byte; sprite 12 is the one whose real Y gets looked at).
+        let mut ppu = eval_ppu(30);
+        for i in 0..8 {
+            set_sprite(&mut ppu, i, 30, 0, 0, 0);
+        }
+        for i in 8..64 {
+            set_sprite(&mut ppu, i, 200, 200, 0xE0, 200);
+        }
+        set_sprite(&mut ppu, 13, 30, 200, 0xE0, 200);
+        step_to(&mut ppu, m.as_mut(), 256);
+        assert!(!ppu.status.contains(PpuStatus::SPRITE_OVERFLOW));
+    }
+
+    /// Sprite 0 with a solid pattern at `x`, over a solid background.
+    fn hit_ppu(x: u8, mask: PpuMask) -> Ppu {
+        let mut ppu = Ppu::new();
+        ppu.mask = mask;
+        ppu.scanline = 50;
+        ppu.sprite_count = 1;
+        ppu.sprite_zero_in_units = true;
+        ppu.sprite_patterns[0] = (0xFF, 0x00);
+        ppu.sprite_positions[0] = x;
+        ppu.sprite_attributes[0] = 0;
+        ppu.bg_shift_pattern_lo = 0xFFFF;
+        ppu.bg_shift_attrib_lo = 0xFFFF;
+        ppu
+    }
+
+    fn hit_at(ppu: &mut Ppu, x: u16) -> bool {
+        ppu.status.remove(PpuStatus::SPRITE_ZERO_HIT);
+        ppu.cycle = x + 1;
+        ppu.render_pixel();
+        ppu.status.contains(PpuStatus::SPRITE_ZERO_HIT)
+    }
+
+    #[test]
+    fn sprite_zero_hit_needs_both_layers_opaque_and_enabled() {
+        let both = PpuMask::SHOW_BG | PpuMask::SHOW_SPRITES;
+        let mut ppu = hit_ppu(100, both);
+        assert!(hit_at(&mut ppu, 100));
+        assert!(!hit_at(&mut ppu, 99), "left of the sprite");
+        assert!(hit_at(&mut ppu, 107));
+        assert!(!hit_at(&mut ppu, 108), "right of the sprite");
+
+        ppu.sprite_attributes[0] = 0x20;
+        assert!(hit_at(&mut ppu, 100), "priority does not matter");
+        ppu.sprite_zero_in_units = false;
+        assert!(!hit_at(&mut ppu, 100), "unit 0 is not sprite 0");
+        ppu.sprite_zero_in_units = true;
+        ppu.bg_shift_pattern_lo = 0;
+        assert!(!hit_at(&mut ppu, 100), "transparent background");
+
+        let mut ppu = hit_ppu(100, PpuMask::SHOW_SPRITES);
+        assert!(!hit_at(&mut ppu, 100), "background disabled");
+        let mut ppu = hit_ppu(100, PpuMask::SHOW_BG);
+        assert!(!hit_at(&mut ppu, 100), "sprites disabled");
+    }
+
+    #[test]
+    fn sprite_zero_hit_respects_left_clip_and_column_255() {
+        let both = PpuMask::SHOW_BG | PpuMask::SHOW_SPRITES;
+        let mut ppu = hit_ppu(3, both);
+        for x in 3..8 {
+            assert!(!hit_at(&mut ppu, x), "x={x} under the clip");
+        }
+        assert!(hit_at(&mut ppu, 8), "first unclipped column");
+
+        let mut ppu = hit_ppu(3, both | PpuMask::SHOW_BG_LEFT);
+        assert!(!hit_at(&mut ppu, 5), "sprites still clipped");
+        let mut ppu = hit_ppu(3, both | PpuMask::SHOW_SPRITES_LEFT);
+        assert!(!hit_at(&mut ppu, 5), "background still clipped");
+        let mut ppu = hit_ppu(3, both | PpuMask::SHOW_BG_LEFT | PpuMask::SHOW_SPRITES_LEFT);
+        assert!(hit_at(&mut ppu, 3), "no clipping");
+
+        let mut ppu = hit_ppu(250, both);
+        assert!(hit_at(&mut ppu, 254));
+        assert!(!hit_at(&mut ppu, 255), "column 255 never hits");
+    }
+
+    #[test]
+    fn sprite_fetch_a12_rises_at_dot_260_and_bg_prefetch_at_324() {
+        // Mapper 4 counts filtered A12 rises; with count 0 and IRQ enabled
+        // every clock sets the flag, so it marks the dot of each rise.
+        let mut m = Mapper4::new(vec![0; 0x8000], tagged_chr(1), Mirroring::Vertical);
+        m.cpu_write(0xC000, 0);
+        m.cpu_write(0xC001, 0);
+        m.cpu_write(0xE001, 0);
+
+        let mut ppu = Ppu::new();
+        ppu.mask = PpuMask::SHOW_BG;
+        ppu.scanline = 100;
+        ppu.cycle = 0;
+        // Sprites at $1000, background at $0000.
+        ppu.ctrl = PpuCtrl::SPRITE_PATTERN;
+        step_to(&mut ppu, &mut m, 259);
+        assert!(!m.irq_pending());
+        ppu.step(&mut m);
+        assert_eq!(ppu.cycle, 260);
+        assert!(m.irq_pending(), "clocked by the first sprite pattern fetch");
+        m.clear_irq();
+        step_to(&mut ppu, &mut m, 340);
+        assert!(!m.irq_pending(), "later slots are inside the filter window");
+
+        // Background at $1000, sprites at $0000: the rise is the prefetch
+        // of the next line's first tile, and the tile fetches at dot 4 of
+        // the following line are still inside the filter window.
+        let mut ppu = Ppu::new();
+        ppu.mask = PpuMask::SHOW_BG;
+        ppu.scanline = 100;
+        ppu.cycle = 0;
+        ppu.ctrl = PpuCtrl::BG_PATTERN;
+        step_to(&mut ppu, &mut m, 256);
+        m.clear_irq();
+        step_to(&mut ppu, &mut m, 323);
+        assert!(!m.irq_pending());
+        ppu.step(&mut m);
+        assert_eq!(ppu.cycle, 324);
+        assert!(m.irq_pending());
+        m.clear_irq();
+        step_to(&mut ppu, &mut m, 340);
+        ppu.step(&mut m);
+        assert_eq!((ppu.scanline, ppu.cycle), (101, 0));
+        step_to(&mut ppu, &mut m, 256);
+        assert!(!m.irq_pending(), "no clock on the next line before 324");
     }
 }

--- a/tests/blargg.rs
+++ b/tests/blargg.rs
@@ -275,62 +275,52 @@ blargg_test!(ppu_open_bus, "ppu_open_bus/ppu_open_bus.nes", SHORT);
 legacy_test!(
     sprite_hit_01_basics,
     "sprite_hit_tests_2005.10.05/01.basics.nes",
-    SHORT,
-    ignore = "FAILED #7 All-transparent sprite should miss; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_02_alignment,
     "sprite_hit_tests_2005.10.05/02.alignment.nes",
-    SHORT,
-    ignore = "FAILED #2 Basic sprite-background alignment is way off; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_03_corners,
     "sprite_hit_tests_2005.10.05/03.corners.nes",
-    SHORT,
-    ignore = "FAILED #2 Lower-right pixel should hit; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_04_flip,
     "sprite_hit_tests_2005.10.05/04.flip.nes",
-    SHORT,
-    ignore = "FAILED #2; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_05_left_clip,
     "sprite_hit_tests_2005.10.05/05.left_clip.nes",
-    SHORT,
-    ignore = "FAILED #4; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_06_right_edge,
     "sprite_hit_tests_2005.10.05/06.right_edge.nes",
-    SHORT,
-    ignore = "FAILED #3; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_07_screen_bottom,
     "sprite_hit_tests_2005.10.05/07.screen_bottom.nes",
-    SHORT,
-    ignore = "FAILED #6; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_08_double_height,
     "sprite_hit_tests_2005.10.05/08.double_height.nes",
-    SHORT,
-    ignore = "FAILED #3; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_09_timing_basics,
     "sprite_hit_tests_2005.10.05/09.timing_basics.nes",
-    SHORT,
-    ignore = "hangs in PPU sync loop; Phase 4/5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_10_timing_order,
     "sprite_hit_tests_2005.10.05/10.timing_order.nes",
-    SHORT,
-    ignore = "hangs in PPU sync loop; Phase 4/5"
+    SHORT
 );
 legacy_test!(
     sprite_hit_11_edge_timing,
@@ -344,26 +334,22 @@ legacy_test!(
 legacy_test!(
     sprite_overflow_1_basics,
     "sprite_overflow_tests/1.Basics.nes",
-    SHORT,
-    ignore = "FAILED #7 Should work normally when $2001 = $08 (bg only); Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_overflow_2_details,
     "sprite_overflow_tests/2.Details.nes",
-    SHORT,
-    ignore = "FAILED #9 Shouldn't be set when all scanlines have 7 or fewer sprites; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_overflow_3_timing,
     "sprite_overflow_tests/3.Timing.nes",
-    SHORT,
-    ignore = "hangs in PPU sync loop; Phase 4/5"
+    SHORT
 );
 legacy_test!(
     sprite_overflow_4_obscure,
     "sprite_overflow_tests/4.Obscure.nes",
-    SHORT,
-    ignore = "FAILED #7; Phase 5"
+    SHORT
 );
 legacy_test!(
     sprite_overflow_5_emulator,
@@ -466,8 +452,7 @@ blargg_test!(
 blargg_test!(
     mmc3_4_scanline_timing,
     "mmc3_test_2/rom_singles/4-scanline_timing.nes",
-    SHORT,
-    ignore = "never reports: needs cycle-exact sprite fetch positions in 257-320; Phase 5"
+    SHORT
 );
 blargg_test!(mmc3_5_mmc3, "mmc3_test_2/rom_singles/5-MMC3.nes", SHORT);
 blargg_test!(


### PR DESCRIPTION
Implements #11: hardware-exact sprite pipeline in `src/ppu/mod.rs`.

## What changed

- **Evaluation over cycles 65-256**: odd dots read `OAM[OAMADDR]`, even dots write secondary OAM; 4-byte copy for in-range sprites; after eight are found the buggy diagonal scan (n and m advance together) sets the overflow flag exactly as nesdev describes. Runs whenever rendering is enabled (bg only included); not on the pre-render line.
- **Fetches over 257-320**, eight dots per slot: two garbage nametable fetches, pattern low, pattern high; tile `$FF` for empty slots and on the pre-render line; `OAMADDR = 0` throughout. Render units are loaded only here, so the line being drawn never sees the next line's evaluation state.
- **`$2004` reads** follow the evaluation unit (copy buffer during 65-256, secondary OAM byte during 257-320).
- **Sprite 0 hit** at the exact pixel with per-layer enable and left-8 clipping, x = 255 excluded; the u8 wrap that dropped sprites at X >= 249 is gone.
- **Background alignment fix**: `increment_x` was skipped at dots 328/336, so every game was drawn 8 px right of its nametable. Found by sprite_hit 02 (single tile at $21F0 vs full overlap sprite: no hit).
- **PPU address bus timing**: the next access's address is driven at the end of the previous access's last dot (nesdev: MMC3 clocks at 260 / 324). Dummy nametable fetches at 337-340 added; A12 filter 8 -> 10 dots so the 9-dot low run across the line boundary does not clock (mmc3_test_2 4 tests 10-13).

Docs: `docs/debugging/PPU_SPRITE_PIPELINE.md` (with the debugging steps), harness table, `docs/README.md`, roadmap Phase 5 status.

## Headless results

| Suite | Before | After |
|---|---|---|
| sprite_hit_tests_2005.10.05 01-11 | 1/11 (11 only) | **11/11** |
| sprite_overflow_tests 1-5 | 1/5 (5 only) | **5/5** |
| mmc3_test_2 | 1/2/3/5 | **1/2/3/4/5** (6 = alternate revision, exclusive with 5, still ignored) |
| nestest (7 checks), ppu_vbl_nmi (11), oam_read, oam_stress, ppu_open_bus | pass | pass |
| `cargo test` (debug, live debug_assert) | | 89 lib + 64 blargg (12 ignored) + 7 nestest pass |

Nothing in the acceptance list remains ignored. Unit tests added for the evaluation cadence and `$2004` visibility, background-only evaluation, the overflow write dot, the diagonal scan bug, sprite 0 hit enable/clip/255 rules, and the A12 rise dots 260 and 324.

## Commercial ROM fingerprints (`cargo test --release --test game_frames -- --ignored --nocapture`)

Every title's hash changed (at f30 too, except where the screen is still blank there), which is unavoidable with the 8-pixel background shift. Frames were dumped headlessly to PNG on main and on this branch and compared by eye:

- **SMB (SuperMarioBros.nes, the SMB/Duck Hunt combo)**: black at every checkpoint on main; now shows the game-select menu with the logo. Please check in-game that the status bar (sprite 0 hit split) is stable and the scroll below it is smooth.
- **SMB3**: title screen identical apart from the shift. Please check the bottom status bar split and the title-screen curtain.
- **Zelda**: the select screen now draws the Link icons and heart cursor that were missing on main. Please check the top status bar / map split during play.
- **Contra**: title identical apart from the shift; please check the in-game screen and that the player sprites and bullets look right.
- **TMNT**: title identical apart from the shift (MMC3 IRQ status bar worth a look).
- **Tetris**: text was already garbled on main and is unchanged apart from the shift; unrelated, deserves its own issue.

## Constraints honoured

Only `src/ppu/mod.rs`, `tests/blargg.rs` and `docs/` touched; no new dependencies; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
