### PR TITLE
fix(apu): implement pulse sweep units

### DIFF
--- a/docs/debugging/APU_FRAME_COUNTER.md
+++ b/docs/debugging/APU_FRAME_COUNTER.md
@@ -134,7 +134,73 @@ The old divider fired at 29828 from cycle 0 and reported 13 (too early).
 
 ## Still open
 
-- Sweep units are still not clocked (`clock_sweeps` is empty), so pitch
-  bends in games do not happen. Envelope and pitch behaviour in real games
-  needs a human listen; the tests only cover what the CPU can read back.
+- Envelope and pitch behaviour in real games needs a human listen; the
+  tests only cover what the CPU can read back and the emulator's own
+  channel state.
 - The DMC memory reader still bypasses the bus and does not stall the CPU.
+
+## Sweep units (issue #21)
+
+`Apu::clock_sweeps` was empty, so `$4001`/`$4005` were stored and never
+acted on and every pulse note played flat. Each `Pulse` now carries a
+sweep unit following nesdev "APU Sweep":
+
+- `$4001`/`$4005` write the enable flag (bit 7), divider period (bits 6-4),
+  negate flag (bit 3) and shift count (bits 2-0), and set the sweep's
+  reload flag. Nothing else changes on the write; the divider is only
+  reloaded on the next half-frame clock.
+- `Pulse::sweep_target` is `period + (period >> shift)` in add mode and
+  `period - (period >> shift)` in negate mode. Pulse 1's adder is one's
+  complement, so it subtracts one more than pulse 2 (`0x100` with shift 1
+  goes to `0x7F` on pulse 1 and `0x80` on pulse 2). A shift of 0 makes the
+  change equal to the whole period. The subtraction saturates at 0; the
+  addition is not clamped to 11 bits because an out-of-range target is
+  what the muting rule looks at.
+- `Pulse::clock_sweep` runs on every half-frame clock (both sequencer modes,
+  and the immediate clock when a 5-step `$4017` write lands). If the divider
+  is 0, the unit is enabled, the shift count is non-zero and the channel is
+  not muted, the period becomes the target. Then, if the divider is 0 or
+  the reload flag is set, the divider is reloaded from the register value
+  and the flag cleared; otherwise it decrements. The check uses the divider
+  value before the reload, so the first clock after a `$4001` write with the
+  divider already at 0 updates the period at once. `timer_counter` is not
+  touched; the new period takes effect when the timer next wraps.
+- `$4002`/`$4003` and `$4006`/`$4007` keep writing `timer_period` as
+  before, and that is the period the sweep reads and rewrites.
+
+### Muting rule
+
+`Pulse::sweep_muted` is true when the current period is below 8 or the
+target period is above `0x7FF`. It is checked continuously in the output
+path, not only on sweep clocks, and it ignores the enable flag and the
+shift count: a disabled sweep with a period of 7 is still silent, and a
+period of `0x700` with add mode and shift 1 (target `0xA80`) is silent even
+with bit 7 clear. Muting also stops the period from being updated, so a
+sweep-down ends with the period parked just below 8 rather than running to
+0. The old output path only checked `period < 8`.
+
+Sweep registers are not reset by `Apu::reset`; like the other channel
+registers they are state the reset line leaves alone.
+
+### Verification
+
+Unit tests in src/apu/mod.rs, clocking half-frames with 5-step `$4017`
+writes as the length counter tests do:
+
+- `sweep_target_period_both_negate_modes`: add and negate targets on both
+  channels, the pulse 1 extra decrement, shift 0 and saturation at 0.
+- `sweep_mutes_on_low_period_and_high_target`: output is 15 at period
+  `0x100`, 0 at period 7, 15 again at 8, 0 at `0x700` with an out-of-range
+  add target while the sweep is disabled, 15 once negate brings the target
+  back in range, and a muted channel's period does not change on a clock.
+- `sweep_down_sequence_on_half_frame_clocks`: `0x100` with negate and
+  shift 1 goes `0x7F, 0x3F, 0x1F, 0x0F, 0x07` on pulse 1 and
+  `0x80, 0x40, 0x20, 0x10` on pulse 2, then stops once muted.
+- `sweep_divider_reload`: with divider period 2 the period changes on
+  clocks 1 and 4, a mid-count `$4001` write reloads the divider on the next
+  clock without changing the period, and shift 0 never updates it.
+
+The blargg suites only read `$4015`, so they cannot see any of this; they
+stay green (apu_test 1-8, apu_reset, cpu_interrupts_v2, nestest). Pitch
+bends in a real game (Mega Man, Contra weapon sounds) still need a human
+listen.

--- a/src/apu/mod.rs
+++ b/src/apu/mod.rs
@@ -104,7 +104,14 @@ pub struct Pulse {
     sweep_period: u8,
     sweep_negate: bool,
     sweep_shift: u8,
-    _sweep_counter: u8,
+    /// Sweep divider, counted down on each half-frame clock.
+    sweep_divider: u8,
+    /// Set by a `$4001`/`$4005` write; the divider reloads on the next
+    /// half-frame clock.
+    sweep_reload: bool,
+    /// Pulse 1's sweep adder uses one's complement, so its negated target
+    /// is one lower than pulse 2's.
+    sweep_ones_complement: bool,
     timer_period: u16,
     timer_counter: u16,
     length: LengthCounter,
@@ -112,7 +119,7 @@ pub struct Pulse {
 }
 
 impl Pulse {
-    fn new() -> Self {
+    fn new(sweep_ones_complement: bool) -> Self {
         Pulse {
             duty: 0,
             volume: 0,
@@ -126,7 +133,9 @@ impl Pulse {
             sweep_period: 0,
             sweep_negate: false,
             sweep_shift: 0,
-            _sweep_counter: 0,
+            sweep_divider: 0,
+            sweep_reload: false,
+            sweep_ones_complement,
             timer_period: 0,
             timer_counter: 0,
             length: LengthCounter::default(),
@@ -143,8 +152,51 @@ impl Pulse {
         }
     }
 
+    /// The period the sweep unit would set: the current period plus or
+    /// minus `period >> shift`. Pulse 1 subtracts one extra when negating
+    /// (one's complement adder). The result is not clamped to 11 bits; a
+    /// target above `0x7FF` mutes the channel instead.
+    fn sweep_target(&self) -> u16 {
+        let change = self.timer_period >> self.sweep_shift;
+        if self.sweep_negate {
+            let extra = u16::from(self.sweep_ones_complement);
+            self.timer_period
+                .saturating_sub(change)
+                .saturating_sub(extra)
+        } else {
+            self.timer_period + change
+        }
+    }
+
+    /// Sweep muting applies continuously, whatever the enable flag and
+    /// shift count: a current period below 8 or a target above `0x7FF`
+    /// silences the channel.
+    fn sweep_muted(&self) -> bool {
+        self.timer_period < 8 || self.sweep_target() > 0x7FF
+    }
+
+    /// Half-frame sweep clock. The period only changes when the divider is
+    /// already 0 and the unit is enabled with a non-zero shift and not
+    /// muting; the divider then reloads when it was 0 or a reload is
+    /// pending, and counts down otherwise.
+    fn clock_sweep(&mut self) {
+        if self.sweep_divider == 0
+            && self.sweep_enabled
+            && self.sweep_shift != 0
+            && !self.sweep_muted()
+        {
+            self.timer_period = self.sweep_target();
+        }
+        if self.sweep_divider == 0 || self.sweep_reload {
+            self.sweep_divider = self.sweep_period;
+            self.sweep_reload = false;
+        } else {
+            self.sweep_divider -= 1;
+        }
+    }
+
     fn _get_output(&self) -> u8 {
-        if !self.length.active() || self.timer_period < 8 {
+        if !self.length.active() || self.sweep_muted() {
             return 0;
         }
 
@@ -513,8 +565,8 @@ impl Default for Apu {
 impl Apu {
     pub fn new() -> Self {
         Apu {
-            pulse1: Pulse::new(),
-            pulse2: Pulse::new(),
+            pulse1: Pulse::new(true),
+            pulse2: Pulse::new(false),
             triangle: Triangle::new(),
             noise: Noise::new(),
             dmc: Dmc::new(),
@@ -608,6 +660,7 @@ impl Apu {
                 self.pulse1.sweep_period = (value >> 4) & 0x07;
                 self.pulse1.sweep_negate = (value & 0x08) != 0;
                 self.pulse1.sweep_shift = value & 0x07;
+                self.pulse1.sweep_reload = true;
             }
             0x4002 => {
                 self.pulse1.timer_period = (self.pulse1.timer_period & 0xFF00) | value as u16;
@@ -632,6 +685,7 @@ impl Apu {
                 self.pulse2.sweep_period = (value >> 4) & 0x07;
                 self.pulse2.sweep_negate = (value & 0x08) != 0;
                 self.pulse2.sweep_shift = value & 0x07;
+                self.pulse2.sweep_reload = true;
             }
             0x4006 => {
                 self.pulse2.timer_period = (self.pulse2.timer_period & 0xFF00) | value as u16;
@@ -866,7 +920,10 @@ impl Apu {
         self.clock_sweeps();
     }
 
-    fn clock_sweeps(&mut self) {}
+    fn clock_sweeps(&mut self) {
+        self.pulse1.clock_sweep();
+        self.pulse2.clock_sweep();
+    }
 
     pub fn get_output(&self) -> f32 {
         let pulse1 = self.pulse1._get_output() as f32;
@@ -1262,5 +1319,166 @@ mod tests {
         assert!(apu.irq_pending());
         apu.write_register(0x4010, 0x0F);
         assert!(!apu.irq_pending());
+    }
+
+    // ---- Sweep units ----
+
+    /// Enable pulse 1 with duty 3 (a 1 at sequence position 0), constant
+    /// volume 15 and a length, so `pulse1_output` is 15 unless muted.
+    fn audible_pulse1(apu: &mut Apu, period: u16) {
+        apu.write_register(0x4015, 0x01);
+        apu.write_register(0x4000, 0xDF);
+        apu.write_register(0x4002, (period & 0xFF) as u8);
+        apu.write_register(0x4003, ((period >> 8) as u8 & 0x07) | 0x08);
+        run(apu, 1);
+    }
+
+    /// Pulse 1 output at sequence position 0, so the duty cycle does not
+    /// depend on how many cycles the test has stepped.
+    fn pulse1_output(apu: &mut Apu) -> u8 {
+        apu.pulse1.sequence_pos = 0;
+        apu.pulse1._get_output()
+    }
+
+    #[test]
+    fn sweep_target_period_both_negate_modes() {
+        let mut apu = Apu::new();
+        apu.write_register(0x4002, 0x00);
+        apu.write_register(0x4003, 0x01); // 0x100
+        apu.write_register(0x4006, 0x00);
+        apu.write_register(0x4007, 0x01);
+
+        // Add mode, shift 2: 0x100 + 0x40.
+        apu.write_register(0x4001, 0x02);
+        apu.write_register(0x4005, 0x02);
+        assert_eq!(apu.pulse1.sweep_target(), 0x140);
+        assert_eq!(apu.pulse2.sweep_target(), 0x140);
+
+        // Negate, shift 2: pulse 1 subtracts one extra (one's complement).
+        apu.write_register(0x4001, 0x0A);
+        apu.write_register(0x4005, 0x0A);
+        assert_eq!(apu.pulse1.sweep_target(), 0x100 - 0x40 - 1);
+        assert_eq!(apu.pulse2.sweep_target(), 0x100 - 0x40);
+
+        // Negate, shift 0: the change is the whole period, so pulse 2's
+        // target is 0 and pulse 1's would be -1, clamped to 0 (not muted).
+        apu.write_register(0x4001, 0x08);
+        apu.write_register(0x4005, 0x08);
+        assert_eq!(apu.pulse1.sweep_target(), 0);
+        assert_eq!(apu.pulse2.sweep_target(), 0);
+        assert!(!apu.pulse1.sweep_muted());
+
+        // Small period, negate, shift 1: 8 - 4 - 1 and 8 - 4.
+        apu.write_register(0x4002, 0x08);
+        apu.write_register(0x4003, 0x00);
+        apu.write_register(0x4006, 0x08);
+        apu.write_register(0x4007, 0x00);
+        apu.write_register(0x4001, 0x09);
+        apu.write_register(0x4005, 0x09);
+        assert_eq!(apu.pulse1.sweep_target(), 3);
+        assert_eq!(apu.pulse2.sweep_target(), 4);
+    }
+
+    #[test]
+    fn sweep_mutes_on_low_period_and_high_target() {
+        let mut apu = Apu::new();
+        audible_pulse1(&mut apu, 0x100);
+        assert_eq!(pulse1_output(&mut apu), 15, "baseline audible");
+
+        apu.write_register(0x4002, 0x07);
+        apu.write_register(0x4003, 0x08); // period 7
+        run(&mut apu, 1);
+        assert!(apu.pulse1.sweep_muted());
+        assert_eq!(pulse1_output(&mut apu), 0, "period below 8 mutes");
+        apu.write_register(0x4002, 0x08); // period 8
+        assert!(!apu.pulse1.sweep_muted());
+        assert_eq!(pulse1_output(&mut apu), 15);
+
+        // Period 0x700, add mode, shift 1: target 0xA80 exceeds 0x7FF.
+        // The sweep is disabled (bit 7 clear) yet still mutes.
+        apu.write_register(0x4002, 0x00);
+        apu.write_register(0x4003, 0x07 | 0x08);
+        run(&mut apu, 1);
+        apu.write_register(0x4001, 0x01);
+        assert_eq!(apu.pulse1.sweep_target(), 0xA80);
+        assert!(apu.pulse1.sweep_muted());
+        assert_eq!(pulse1_output(&mut apu), 0, "target above 0x7FF mutes");
+
+        // Negate mode brings the target back in range: audible again.
+        apu.write_register(0x4001, 0x09);
+        assert!(!apu.pulse1.sweep_muted());
+        assert_eq!(pulse1_output(&mut apu), 15);
+
+        // Muting does not change the period on a clock even when enabled.
+        apu.write_register(0x4001, 0x81);
+        write_4017(&mut apu, 0x80);
+        assert_eq!(apu.pulse1.timer_period, 0x700);
+    }
+
+    /// Enabled, divider period 0, negate, shift 1: each half-frame halves
+    /// the period, with pulse 1 one lower than pulse 2.
+    #[test]
+    fn sweep_down_sequence_on_half_frame_clocks() {
+        let mut apu = Apu::new();
+        apu.write_register(0x4002, 0x00);
+        apu.write_register(0x4003, 0x01);
+        apu.write_register(0x4006, 0x00);
+        apu.write_register(0x4007, 0x01);
+        apu.write_register(0x4001, 0x89);
+        apu.write_register(0x4005, 0x89);
+
+        let expected1 = [0x7F, 0x3F, 0x1F, 0x0F];
+        let expected2 = [0x80, 0x40, 0x20, 0x10];
+        for i in 0..4 {
+            write_4017(&mut apu, 0x80); // one half-frame clock
+            assert_eq!(apu.pulse1.timer_period, expected1[i], "pulse 1 clock {}", i);
+            assert_eq!(apu.pulse2.timer_period, expected2[i], "pulse 2 clock {}", i);
+        }
+
+        // Once the period drops below 8 the channel mutes and stops moving.
+        write_4017(&mut apu, 0x80);
+        assert_eq!(apu.pulse1.timer_period, 0x07);
+        assert!(apu.pulse1.sweep_muted());
+        write_4017(&mut apu, 0x80);
+        assert_eq!(apu.pulse1.timer_period, 0x07);
+    }
+
+    /// The divider only lets the period change when it is 0; a `$4001`
+    /// write reloads it on the next clock.
+    #[test]
+    fn sweep_divider_reload() {
+        let mut apu = Apu::new();
+        apu.write_register(0x4002, 0x00);
+        apu.write_register(0x4003, 0x01); // 0x100
+        apu.write_register(0x4001, 0xA1); // enabled, P=2, add, shift 1
+
+        write_4017(&mut apu, 0x80); // divider 0: update, reload to 2
+        assert_eq!(apu.pulse1.timer_period, 0x180);
+        assert_eq!(apu.pulse1.sweep_divider, 2);
+        write_4017(&mut apu, 0x80); // 2 -> 1
+        assert_eq!(apu.pulse1.timer_period, 0x180);
+        write_4017(&mut apu, 0x80); // 1 -> 0
+        assert_eq!(apu.pulse1.timer_period, 0x180);
+        assert_eq!(apu.pulse1.sweep_divider, 0);
+        write_4017(&mut apu, 0x80); // 0: update again
+        assert_eq!(apu.pulse1.timer_period, 0x240);
+        assert_eq!(apu.pulse1.sweep_divider, 2);
+
+        // A register write while the divider is mid-count reloads it on the
+        // next clock without changing the period on that clock.
+        write_4017(&mut apu, 0x80); // 2 -> 1
+        apu.write_register(0x4001, 0xB1); // P=3, reload pending
+        assert!(apu.pulse1.sweep_reload);
+        write_4017(&mut apu, 0x80);
+        assert_eq!(apu.pulse1.timer_period, 0x240);
+        assert_eq!(apu.pulse1.sweep_divider, 3);
+        assert!(!apu.pulse1.sweep_reload);
+
+        // Shift 0 never updates the period, even with the divider at 0.
+        apu.write_register(0x4001, 0x80);
+        for _ in 0..3 {
+            write_4017(&mut apu, 0x80);
+        }
+        assert_eq!(apu.pulse1.timer_period, 0x240);
     }
 }


### PR DESCRIPTION
## Summary

`Apu::clock_sweeps` was empty, so `$4001`/`$4005` were stored and never acted on and every pulse note played flat. Each `Pulse` now has a sweep unit per nesdev "APU Sweep":

- Divider, reload flag, and enable/period/negate/shift from `$4001`/`$4005`; the register write sets the reload flag.
- Target period = period plus or minus `period >> shift`. Pulse 1 uses a one's complement adder and subtracts one extra when negating; pulse 2 does not.
- Clocked on every half-frame. The period changes only when the divider is 0, the sweep is enabled, the shift is non-zero and the channel is not muted; the divider then reloads when it was 0 or a reload is pending, else counts down.
- Muting is continuous and ignores the enable flag and shift count: output is 0 whenever the current period is below 8 or the target exceeds `0x7FF`. This replaces the old `period < 8` check in the output path.
- `$4002`/`$4003` and `$4006`/`$4007` keep writing `timer_period`, which is what the sweep reads and rewrites.

Documented in `docs/debugging/APU_FRAME_COUNTER.md` under "Sweep units".

## What the unit tests verify (src/apu/mod.rs)

- `sweep_target_period_both_negate_modes`: add and negate targets on both channels, the pulse 1 extra decrement, shift 0 (change equals the whole period) and saturation at 0.
- `sweep_mutes_on_low_period_and_high_target`: output is 15 at period `0x100`, 0 at period 7, 15 again at 8, 0 at `0x700` with an out-of-range add target while the sweep is disabled, 15 once negate brings the target back in range, and a muted channel's period does not change on a clock.
- `sweep_down_sequence_on_half_frame_clocks`: `0x100` with negate and shift 1 goes `0x7F, 0x3F, 0x1F, 0x0F, 0x07` on pulse 1 and `0x80, 0x40, 0x20, 0x10` on pulse 2, then stops once muted.
- `sweep_divider_reload`: with divider period 2 the period changes on clocks 1 and 4, a mid-count `$4001` write reloads the divider on the next clock without changing the period, and shift 0 never updates it.

## Test plan

- `cargo build`, `cargo test` (debug): 100 unit tests, 75 blargg suites and nestest pass. `apu_test` 1-8 and combined, `apu_reset` (all six), `cpu_interrupts_v2` 1-5 and combined stay green. The blargg suites only read `$4015`, so they cannot observe sweep behaviour.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- Not verified: pitch bends in a real game (Mega Man, Contra weapon sounds) need a human listen before the issue's done criterion is met.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
