### PR TITLE
feat(cartridge): persist battery-backed PRG RAM to a .sav file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Contains debugging session notes and references:
 - `APU_FRAME_COUNTER.md` - frame sequencer schedule, three-cycle IRQ flag window, length counter enable/halt, power-up and reset state (#18)
 - `PPU_SPRITE_PIPELINE.md` - Per-dot sprite evaluation and fetch, overflow scan bug, sprite 0 hit rules, 8-pixel background shift fix, MMC3 A12 dot timing (#11)
 - `TETRIS_MMC1_FIX.md` - Tetris garbled tiles traced to an archaic DiskDude iNES header read as mapper 65; header sanitising in the cartridge loader (#22)
+- `BATTERY_SAVES.md` - Battery-backed PRG RAM persisted to a .sav file next to the ROM; Mapper prg_ram accessors, System::load_battery/save_battery, hash-based dirty flush (#26)
 
 ### `/plans/`
 Contains implementation plans and roadmaps:

--- a/docs/debugging/BATTERY_SAVES.md
+++ b/docs/debugging/BATTERY_SAVES.md
@@ -1,0 +1,156 @@
+# Battery-Backed PRG RAM Saves
+
+**Date:** 2026-09-05
+**Type:** Feature / Persistence
+**Severity:** High (every battery game lost all progress on quit)
+**Status:** Complete (headless); human check of the SDL binary pending
+**Tracking:** GitHub issue #26
+
+## Executive Summary
+
+`Cartridge::load_from_bytes` has always recorded iNES flags 6 bit 1
+(`battery_backed`), but nothing read it. Every mapper owns an 8 KB
+`prg_ram` array that is zeroed on construction, so The Legend of Zelda,
+Final Fantasy, Dragon Warrior and every other battery game started from an
+empty save table each launch.
+
+PRG RAM is now written to a `.sav` file next to the ROM and read back on
+the next launch. The mapper trait gained two accessor methods so `System`
+can reach PRG RAM without knowing which board it is talking to, and the
+persistence logic lives in two `System` methods that the binary and the
+tests share.
+
+## Design
+
+### Mapper trait (`src/cartridge/mapper.rs`)
+
+```rust
+fn prg_ram(&self) -> Option<&[u8]> { None }
+fn prg_ram_mut(&mut self) -> Option<&mut [u8]> { None }
+```
+
+Implemented by mappers 0, 1, 2, 3, 4, 5 and 65, all of which own a
+`[u8; 0x2000]`. No other trait method changed.
+
+MMC3 (`mapper4.rs`) returns the raw array regardless of its `$A001`
+enable and write-protect bits. Those bits gate the CPU bus, not the
+battery: a game that disables PRG RAM before jumping to its reset vector
+still expects the contents to be there when it re-enables them.
+
+MMC5 exposes only its 8 KB `prg_ram`, not ExRAM. ExRAM is not battery
+backed on any known board.
+
+### `System` API (`src/system.rs`, after the debug helpers)
+
+```rust
+pub fn load_battery(&mut self, path: &Path) -> io::Result<bool>
+pub fn save_battery(&self, path: &Path) -> io::Result<bool>
+```
+
+Both are no-ops returning `Ok(false)` unless the loaded cartridge is
+battery backed and its mapper reports PRG RAM.
+
+`load_battery`:
+
+- File missing: `Ok(false)`, RAM untouched. This is the normal first
+  launch and is logged at info level by the binary, not as an error.
+- File size differs from the board's PRG RAM: `log::warn!` and
+  `Ok(false)`, RAM untouched. The next flush overwrites the file.
+- Otherwise the file replaces PRG RAM, the hash below is recorded, and
+  `Ok(true)` is returned with an info log line.
+- Any other I/O error propagates.
+
+`save_battery`:
+
+- Hashes PRG RAM with `std::hash::DefaultHasher` and compares it with the
+  hash recorded by the last successful load or save. Equal: `Ok(false)`,
+  nothing written.
+- Otherwise writes the whole array, records the hash and returns
+  `Ok(true)` with an info log line.
+
+### Dirty tracking
+
+The recorded hash lives in `System::battery_saved_hash: Cell<Option<u64>>`.
+`Cell` lets `save_battery` take `&self`, which keeps it callable from a
+context that only holds a shared reference (an OSD or a stop hook) and
+keeps the dirty state out of the emulation path entirely: no write hook
+in the mapper, no per-frame comparison. Hashing 8 KB once every five
+seconds is far below one frame of emulation. `Cell<u64>` is `Send`, so
+`System` still travels through `Arc<Mutex<System>>` if that returns.
+
+A hash rather than a stored copy was chosen because the comparison cost
+is the same (both walk 8 KB) and the hash needs no second buffer.
+`DefaultHasher::new()` is deterministic within a process, which is all
+that is required; the value is never persisted.
+
+`load_cartridge` resets the hash to `None` so the first flush after a
+cartridge swap always writes.
+
+### Binary (`src/main.rs`)
+
+- Save path is the ROM path with its extension replaced by `.sav`
+  (`Path::with_extension`), so `roms/Zelda.nes` pairs with
+  `roms/Zelda.sav`.
+- `load_battery` runs immediately after `load_cartridge`, before the loop.
+- `save_battery` runs every `BATTERY_FLUSH_INTERVAL` (5 s) after the
+  present, and once more after the loop exits. Both Quit and Escape leave
+  through `break 'running`, so the post-loop call covers every exit path.
+  A crash or `kill -9` loses at most five seconds of progress.
+- Write failures are logged as warnings and never abort emulation.
+
+### What is deliberately not done
+
+- No atomic rename on write. A crash mid-write can truncate the file,
+  which the next launch rejects on size and overwrites five seconds
+  later. Worth revisiting if the flush interval grows.
+- No save-state (whole machine) support; this is PRG RAM only.
+- No configurable save directory; the sidecar file matches what most
+  emulators default to and what users expect to find next to the ROM.
+
+## Verification
+
+### Headless (`cargo test --test battery`, 4 tests)
+
+All four use a synthetic 32 KB NROM image (`tests/battery.rs`), write
+PRG RAM through `System::poke`, read it back through `System::peek`, and
+use a per-process, per-test file under `std::env::temp_dir()`.
+
+| Test | Verifies |
+|------|----------|
+| `battery_ram_round_trips_between_systems` | A patterned 8 KB write, `save_battery` returning `Ok(true)`, a fresh `System` loading it with `Ok(true)`, and every byte matching. This is the two-instance round trip the issue asks for. |
+| `unchanged_ram_is_not_rewritten` | Second save with no change returns `Ok(false)`; one changed byte triggers a write that lands on disk; a freshly loaded system reports nothing dirty. |
+| `non_battery_rom_never_writes_or_reads` | With flags 6 bit 1 clear, `save_battery` never creates a file and `load_battery` ignores an existing one. |
+| `missing_file_and_size_mismatch_are_ignored` | Missing file and a 4 KB file both return `Ok(false)` and leave RAM zero; the next save replaces the bad file with a full 8 KB. |
+
+The full suite (`cargo test`) and `cargo clippy --all-targets -- -D warnings`
+pass with the change.
+
+### Human check still needed
+
+Run the SDL binary with Zelda: start a file, name it, play into the first
+screen, quit with Escape, relaunch. The file select screen should show
+the named file. Expect these log lines with `RUST_LOG=info`:
+
+```
+No battery save at roms/Zelda.sav        (first launch only)
+Wrote battery save roms/Zelda.sav (8192 bytes)
+Loaded battery save roms/Zelda.sav (8192 bytes)   (second launch)
+```
+
+Final Fantasy (MMC1, battery) is a second good candidate because it
+writes its save table on an explicit menu action rather than
+continuously, which exercises the dirty check.
+
+## Debugging notes
+
+- `Ignoring battery save ...: N bytes, expected 8192` in the log means a
+  `.sav` from another emulator that uses a different size or prepends a
+  header. Delete it, or strip it down to the raw 8 KB PRG RAM image.
+- A `.sav` that never appears: check the ROM header. `Cartridge::mapper_id`
+  is logged at load; add `battery_backed` to that line if a ROM dump has
+  the flag stripped. The binary only touches the file when the flag is
+  set.
+- To inspect a save: `xxd roms/Zelda.sav | head`. The file is the raw
+  `$6000-$7FFF` image, so offset 0 is `$6000`. An all-zero file means the
+  game never wrote PRG RAM, which points at the game not reaching its
+  save code rather than at persistence.

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -47,6 +47,19 @@ pub trait Mapper: Send {
     /// that A12 must have been low for several PPU cycles first. MMC3 clocks
     /// its IRQ counter here. No-op for everything else.
     fn ppu_a12_rise(&mut self) {}
+
+    /// Borrow the board's PRG RAM ($6000-$7FFF) for battery persistence.
+    /// `None` for boards without PRG RAM. Returns the raw array even when
+    /// the board has gated it off the bus (MMC3 $A001), since that gate
+    /// controls CPU access, not what the battery keeps.
+    fn prg_ram(&self) -> Option<&[u8]> {
+        None
+    }
+
+    /// Mutable counterpart of `prg_ram`, used to restore a save file.
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        None
+    }
 }
 
 /// Mapper used when no cartridge is loaded: open bus everywhere.

--- a/src/cartridge/mapper0.rs
+++ b/src/cartridge/mapper0.rs
@@ -70,6 +70,14 @@ impl Mapper for Mapper0 {
     fn mirroring(&self) -> Mirroring {
         self.mirroring
     }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
 }
 
 #[cfg(test)]

--- a/src/cartridge/mapper1.rs
+++ b/src/cartridge/mapper1.rs
@@ -158,6 +158,14 @@ impl Mapper for Mapper1 {
             _ => Mirroring::Horizontal,
         }
     }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
 }
 
 #[cfg(test)]

--- a/src/cartridge/mapper2.rs
+++ b/src/cartridge/mapper2.rs
@@ -69,6 +69,14 @@ impl Mapper for Mapper2 {
     fn mirroring(&self) -> Mirroring {
         self.mirroring
     }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
 }
 
 #[cfg(test)]

--- a/src/cartridge/mapper3.rs
+++ b/src/cartridge/mapper3.rs
@@ -60,6 +60,14 @@ impl Mapper for Mapper3 {
     fn mirroring(&self) -> Mirroring {
         self.mirroring
     }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
 }
 
 #[cfg(test)]

--- a/src/cartridge/mapper4.rs
+++ b/src/cartridge/mapper4.rs
@@ -248,6 +248,14 @@ impl Mapper for Mapper4 {
             self.irq_pending = true;
         }
     }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
 }
 
 #[cfg(test)]

--- a/src/cartridge/mapper5.rs
+++ b/src/cartridge/mapper5.rs
@@ -330,6 +330,14 @@ impl Mapper for Mapper5 {
             self.scanline_counter = self.scanline_counter.wrapping_add(1);
         }
     }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
 }
 
 #[cfg(test)]

--- a/src/cartridge/mapper65.rs
+++ b/src/cartridge/mapper65.rs
@@ -80,6 +80,14 @@ impl Mapper for Mapper65 {
     fn mirroring(&self) -> Mirroring {
         self.mirroring
     }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use sdl2::render::TextureCreator;
 use sdl2::video::WindowContext;
 use std::collections::VecDeque;
 use std::env;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -27,6 +28,10 @@ const AUDIO_TARGET_SAMPLES: usize = 2450;
 /// Samples per SDL callback. Smaller callbacks mean smaller dips in the
 /// queue between presents.
 const AUDIO_DEVICE_SAMPLES: u16 = 512;
+
+/// How often battery-backed PRG RAM is flushed to the .sav file while
+/// running. `System::save_battery` only writes when the RAM changed.
+const BATTERY_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Pixels hidden on every edge of the picture by default. A CRT never
 /// shows them, and games rely on that: Final Fantasy draws the map row
@@ -83,6 +88,7 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!("Usage: {} <rom_file> [--no-audio] [--full-frame]", args[0]);
+        eprintln!("Battery-backed games read and write <rom_file with .sav extension>.");
         std::process::exit(1);
     }
 
@@ -173,7 +179,20 @@ fn main() -> Result<()> {
     };
 
     let mut system = System::new();
+    let battery_backed = cartridge.battery_backed;
     system.load_cartridge(cartridge);
+
+    // Battery-backed PRG RAM lives next to the ROM as <rom>.sav. Loaded
+    // once here, flushed every few seconds below and once more on exit.
+    let save_path = Path::new(rom_path).with_extension("sav");
+    if battery_backed {
+        match system.load_battery(&save_path) {
+            Ok(true) => {}
+            Ok(false) => log::info!("No battery save at {}", save_path.display()),
+            Err(e) => log::warn!("Could not read {}: {}", save_path.display(), e),
+        }
+    }
+    let mut last_battery_flush = Instant::now();
 
     let frame_duration = Duration::from_nanos(16_666_667);
     let mut _last_frame = Instant::now();
@@ -311,6 +330,13 @@ fn main() -> Result<()> {
 
         canvas.present();
 
+        if last_battery_flush.elapsed() >= BATTERY_FLUSH_INTERVAL {
+            last_battery_flush = Instant::now();
+            if let Err(e) = system.save_battery(&save_path) {
+                log::warn!("Could not write {}: {}", save_path.display(), e);
+            }
+        }
+
         let elapsed = frame_start.elapsed();
         if audio_buffer.is_some() {
             // Audio paces emulation; just avoid spinning between presents.
@@ -324,6 +350,10 @@ fn main() -> Result<()> {
         }
 
         _last_frame = Instant::now();
+    }
+
+    if let Err(e) = system.save_battery(&save_path) {
+        log::warn!("Could not write {}: {}", save_path.display(), e);
     }
 
     log::info!("Emulation stopped.");

--- a/src/system.rs
+++ b/src/system.rs
@@ -2,7 +2,11 @@ use crate::apu::Apu;
 use crate::cartridge::{Cartridge, Mapper, NullMapper};
 use crate::input::Controller;
 use crate::ppu::Ppu;
+use std::cell::Cell;
 use std::collections::VecDeque;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::io;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 // Interrupt tests live in src/system/tests.rs (a child module, so they can
@@ -83,6 +87,11 @@ pub struct System {
     /// loaded mapper's own `irq_pending()`. Used by tests to drive the line
     /// without a cartridge that has an IRQ counter.
     pub mapper_irq: bool,
+    /// Hash of PRG RAM as last loaded from or written to the battery save
+    /// file, so a periodic `save_battery` can skip the write when nothing
+    /// changed. `None` until the first load or save. A `Cell` so
+    /// `save_battery` can take `&self` (docs/debugging/BATTERY_SAVES.md).
+    battery_saved_hash: Cell<Option<u64>>,
 }
 
 impl Default for System {
@@ -107,6 +116,7 @@ impl System {
             controller2: Controller::new(),
             cartridge: None,
             null_mapper: NullMapper,
+            battery_saved_hash: Cell::new(None),
             instr_cycles: 0,
             dma_in_instr: false,
             audio_sample_counter: 0.0,
@@ -174,6 +184,7 @@ impl System {
         // Pattern tables and mirroring are served by the cartridge mapper on
         // every PPU access, so nothing is copied into the PPU here.
         self.cartridge = Some(cartridge);
+        self.battery_saved_hash.set(None);
         self.reset();
     }
 
@@ -3016,6 +3027,92 @@ impl System {
 
     pub fn pc(&self) -> u16 {
         self.cpu_pc
+    }
+
+    // ------------------------------------------------------------------
+    // Battery-backed PRG RAM persistence (docs/debugging/BATTERY_SAVES.md).
+    // ------------------------------------------------------------------
+
+    /// PRG RAM of the loaded cartridge if, and only if, the iNES header
+    /// flags it as battery backed and the mapper exposes PRG RAM.
+    fn battery_ram(&self) -> Option<&[u8]> {
+        let cart = self.cartridge.as_ref()?;
+        if !cart.battery_backed {
+            return None;
+        }
+        cart.mapper.prg_ram()
+    }
+
+    fn hash_ram(ram: &[u8]) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        ram.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Restore battery-backed PRG RAM from `path`.
+    ///
+    /// Returns `Ok(false)` without touching RAM when the cartridge is not
+    /// battery backed, when the file does not exist, or when its size does
+    /// not match the board's PRG RAM (logged as a warning). Other I/O
+    /// errors are returned. `Ok(true)` means RAM was replaced by the file.
+    pub fn load_battery(&mut self, path: &Path) -> io::Result<bool> {
+        let expected = match self.battery_ram() {
+            Some(ram) => ram.len(),
+            None => return Ok(false),
+        };
+        let data = match std::fs::read(path) {
+            Ok(data) => data,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(e),
+        };
+        if data.len() != expected {
+            log::warn!(
+                "Ignoring battery save {}: {} bytes, expected {}",
+                path.display(),
+                data.len(),
+                expected
+            );
+            return Ok(false);
+        }
+        let ram = self
+            .cartridge
+            .as_mut()
+            .and_then(|cart| cart.mapper.prg_ram_mut())
+            .expect("battery_ram() checked the cartridge and mapper");
+        ram.copy_from_slice(&data);
+        self.battery_saved_hash.set(Some(Self::hash_ram(ram)));
+        log::info!(
+            "Loaded battery save {} ({} bytes)",
+            path.display(),
+            expected
+        );
+        Ok(true)
+    }
+
+    /// Write battery-backed PRG RAM to `path` if it changed since the last
+    /// load or save.
+    ///
+    /// Returns `Ok(false)` when the cartridge is not battery backed or when
+    /// PRG RAM is identical to what was last loaded or written, so a caller
+    /// may invoke this every few seconds; nothing is written in that case.
+    /// `Ok(true)` means the file was (re)written.
+    pub fn save_battery(&self, path: &Path) -> io::Result<bool> {
+        let ram = match self.battery_ram() {
+            Some(ram) => ram,
+            None => return Ok(false),
+        };
+        let hash = Self::hash_ram(ram);
+        if self.battery_saved_hash.get() == Some(hash) {
+            return Ok(false);
+        }
+        std::fs::write(path, ram)?;
+        self.battery_saved_hash.set(Some(hash));
+        log::info!(
+            "Wrote battery save {} ({} bytes)",
+            path.display(),
+            ram.len()
+        );
+        Ok(true)
     }
 
     pub fn set_pc(&mut self, pc: u16) {

--- a/tests/battery.rs
+++ b/tests/battery.rs
@@ -1,0 +1,160 @@
+//! Battery-backed PRG RAM persistence (issue #26,
+//! docs/debugging/BATTERY_SAVES.md).
+//!
+//! Each test builds a synthetic 32 KB NROM image and drives the public
+//! `System::save_battery` / `System::load_battery` API, the same code path
+//! the SDL binary uses. Save files go under `std::env::temp_dir()` with a
+//! per-process, per-test name and are removed afterwards.
+
+use nes_emu::cartridge::Cartridge;
+use nes_emu::system::System;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const PRG_RAM_START: u16 = 0x6000;
+const PRG_RAM_SIZE: usize = 0x2000;
+
+/// 16-byte header plus 32 KB of NOPs with a reset vector at $8000.
+/// `battery` sets flags 6 bit 1.
+fn synthetic_rom(battery: bool) -> Vec<u8> {
+    let mut rom = Vec::with_capacity(16 + 0x8000);
+    rom.extend_from_slice(b"NES\x1A");
+    rom.push(2); // 2 x 16 KB PRG
+    rom.push(0); // CHR RAM
+    rom.push(if battery { 0x02 } else { 0x00 });
+    rom.push(0);
+    rom.extend_from_slice(&[0; 8]);
+    let mut prg = vec![0xEA; 0x8000];
+    prg[0x7FFC] = 0x00;
+    prg[0x7FFD] = 0x80;
+    rom.extend_from_slice(&prg);
+    rom
+}
+
+fn system_with(battery: bool) -> System {
+    let cart = Cartridge::load_from_bytes(&synthetic_rom(battery)).expect("synthetic ROM");
+    assert_eq!(cart.battery_backed, battery);
+    let mut system = System::new();
+    system.load_cartridge(cart);
+    system
+}
+
+fn temp_sav(tag: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "nes-emu-battery-{}-{}-{}.sav",
+        tag,
+        std::process::id(),
+        nanos
+    ))
+}
+
+/// Deterministic, non-trivial fill so a partial or shifted restore fails.
+fn pattern(i: usize) -> u8 {
+    (i.wrapping_mul(31) ^ (i >> 5)) as u8
+}
+
+fn fill_prg_ram(system: &mut System) {
+    for i in 0..PRG_RAM_SIZE {
+        system.poke(PRG_RAM_START + i as u16, pattern(i));
+    }
+}
+
+#[test]
+fn battery_ram_round_trips_between_systems() {
+    let path = temp_sav("roundtrip");
+
+    let mut first = system_with(true);
+    fill_prg_ram(&mut first);
+    assert!(first.save_battery(&path).unwrap(), "first save writes");
+    assert_eq!(std::fs::metadata(&path).unwrap().len(), PRG_RAM_SIZE as u64);
+
+    let mut second = system_with(true);
+    assert_eq!(second.peek(PRG_RAM_START), 0, "fresh PRG RAM is zero");
+    assert!(second.load_battery(&path).unwrap(), "save is loaded");
+    for i in 0..PRG_RAM_SIZE {
+        assert_eq!(
+            second.peek(PRG_RAM_START + i as u16),
+            pattern(i),
+            "byte {i} after load"
+        );
+    }
+
+    std::fs::remove_file(&path).unwrap();
+}
+
+#[test]
+fn unchanged_ram_is_not_rewritten() {
+    let path = temp_sav("dirty");
+
+    let mut system = system_with(true);
+    fill_prg_ram(&mut system);
+    assert!(system.save_battery(&path).unwrap());
+    assert!(
+        !system.save_battery(&path).unwrap(),
+        "second save with no changes is skipped"
+    );
+
+    system.poke(PRG_RAM_START + 0x100, !pattern(0x100));
+    assert!(
+        system.save_battery(&path).unwrap(),
+        "a changed byte is written"
+    );
+    let on_disk = std::fs::read(&path).unwrap();
+    assert_eq!(on_disk[0x100], !pattern(0x100));
+
+    // Loading marks the current contents as saved as well.
+    let mut other = system_with(true);
+    assert!(other.load_battery(&path).unwrap());
+    assert!(!other.save_battery(&path).unwrap());
+
+    std::fs::remove_file(&path).unwrap();
+}
+
+#[test]
+fn non_battery_rom_never_writes_or_reads() {
+    let path = temp_sav("nobattery");
+
+    let mut system = system_with(false);
+    fill_prg_ram(&mut system);
+    assert!(!system.save_battery(&path).unwrap());
+    assert!(!path.exists(), "no file for a non-battery cartridge");
+
+    // Even with a file present, a non-battery cartridge ignores it.
+    std::fs::write(&path, vec![0x55; PRG_RAM_SIZE]).unwrap();
+    let mut fresh = system_with(false);
+    assert!(!fresh.load_battery(&path).unwrap());
+    assert_eq!(fresh.peek(PRG_RAM_START), 0);
+
+    std::fs::remove_file(&path).unwrap();
+}
+
+#[test]
+fn missing_file_and_size_mismatch_are_ignored() {
+    let path = temp_sav("mismatch");
+
+    let mut system = system_with(true);
+    assert!(
+        !system.load_battery(&path).unwrap(),
+        "missing file is Ok(false)"
+    );
+
+    std::fs::write(&path, vec![0xAA; PRG_RAM_SIZE / 2]).unwrap();
+    assert!(
+        !system.load_battery(&path).unwrap(),
+        "wrong size is Ok(false)"
+    );
+    for i in 0..PRG_RAM_SIZE {
+        assert_eq!(system.peek(PRG_RAM_START + i as u16), 0, "RAM untouched");
+    }
+
+    // The mismatched file is replaced on the next save.
+    fill_prg_ram(&mut system);
+    assert!(system.save_battery(&path).unwrap());
+    assert_eq!(std::fs::metadata(&path).unwrap().len(), PRG_RAM_SIZE as u64);
+
+    std::fs::remove_file(&path).unwrap();
+}


### PR DESCRIPTION
Closes #26

## What

Battery-backed PRG RAM is now persisted to a `.sav` file next to the ROM.

- `Mapper` trait: `prg_ram(&self) -> Option<&[u8]>` and `prg_ram_mut` with default `None`, implemented by mappers 0, 1, 2, 3, 4, 5 and 65. Mapper 2 (UxROM) was included beyond the issue list because it owns the same 8 KB array. MMC3 returns the raw array regardless of its `$A001` enable/write-protect bits (those gate the bus, not the battery). No other trait method changed.
- `System::load_battery(&mut self, &Path) -> io::Result<bool>` and `System::save_battery(&self, &Path) -> io::Result<bool>`. Both are `Ok(false)` no-ops for non-battery cartridges. Missing file and size mismatch (warned) are `Ok(false)` with RAM untouched. Dirty tracking is a `Cell<Option<u64>>` hash of the last loaded/saved contents, so `save_battery` can take `&self` and the periodic flush costs one 8 KB hash every 5 s with no per-write hook in the mapper.
- `src/main.rs`: save path is the ROM path with a `.sav` extension; load right after `load_cartridge`; flush every 5 s after the present and once more after the loop. Quit and Escape both `break 'running` into that post-loop flush, so a single call covers every exit path. Load and write are logged at info level from `System` so the binary and tests share the code path.
- Docs: `docs/debugging/BATTERY_SAVES.md` plus a line in `docs/README.md` and the usage line in `main.rs`.

Touch points in `src/system.rs` outside the debug-API section, for whoever merges against the DMC lane: five `use` lines at the top, one `battery_saved_hash` field on the struct, its initialiser in `new()`, and one reset line in `load_cartridge`. No tick/cpu_step changes. `build_mapper` in `cartridge/mod.rs` was not touched.

## Tests (`tests/battery.rs`, synthetic mapper-0 ROM, files under `std::env::temp_dir()`)

- `battery_ram_round_trips_between_systems`: poke a pattern into all 8 KB, `save_battery` returns `Ok(true)`, a fresh `System` loads it with `Ok(true)`, every byte reads back via `peek`. This is the two-instance round trip from the issue.
- `unchanged_ram_is_not_rewritten`: second save with no change is `Ok(false)`; one changed byte triggers a write that lands on disk; a freshly loaded system reports nothing dirty.
- `non_battery_rom_never_writes_or_reads`: with flags 6 bit 1 clear, no file is ever created and an existing file is ignored on load.
- `missing_file_and_size_mismatch_are_ignored`: missing file and a 4 KB file both return `Ok(false)` leaving RAM zero; the next save replaces the bad file with a full 8 KB.

Gates: `cargo build`, `cargo test` (all suites), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all pass.

## Needs a human check

A real Zelda save round trip in the SDL binary has not been verified. Run with `RUST_LOG=info`, start and name a file, quit with Escape, relaunch, and confirm the file select screen shows it. Expected log lines: `No battery save at roms/Zelda.sav` (first launch), `Wrote battery save roms/Zelda.sav (8192 bytes)`, `Loaded battery save roms/Zelda.sav (8192 bytes)` (second launch). Final Fantasy is a good second candidate since it writes its save table on an explicit menu action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
