### PR TITLE
feat(cartridge): add mapper 227 for address-latch multicarts

### DIFF
--- a/docs/debugging/MAPPER_TRAIT_REFACTOR.md
+++ b/docs/debugging/MAPPER_TRAIT_REFACTOR.md
@@ -116,6 +116,54 @@ using the mirroring the mapper reports at that moment.
 | `mapper4.rs` | MMC3 | Rewritten to absolute addresses; `clock_scanline` is byte-for-byte the old counter. `$A001` bit 7 enables PRG RAM (default enabled), bit 6 write-protects. Nothing calls `clock_scanline` yet; issue #3 wires the A12 edge and delivers the IRQ. |
 | `mapper5.rs` | MMC5 | Wired for the first time. PRG/CHR modes, multiplier, ExRAM, register file. ExRAM nametables, fill mode and the vertical split are recorded but not rendered (the PPU has no per-table nametable hook); `mirroring()` approximates `$5105`. |
 | `mapper65.rs` | Irem H3001 | Moved out of `mod.rs`. CHR registers corrected from `$9000-$9007` to `$B000-$B007` (nesdev); the old offset never mattered because CHR never reached the PPU. |
+| `mapper227.rs` | Address-latch multicart (1200-in-1) | Added for issue 25, see below. |
+
+### Mapper 227 (issue 25)
+
+The 1200-in-1 multicart (`roms/1200-in-1.nes`, 512 KB PRG, CHR RAM) is
+iNES mapper 227. The register is the CPU address of any write to
+`$8000-$FFFF`; the data byte is ignored. Per nesdev "INES Mapper 227":
+
+```text
+[A~1... .mLQ OQQP PpMS]
+         ||| |||| |||+- S: 0 = 16 KB mode, 1 = 32 KB mode (PRG A14 = CPU A14)
+         ||| |||| ||+-- M: 0 = vertical mirroring, 1 = horizontal
+         ||| |||+-++--- PPp: inner 16 KB bank (PRG A16..A14)
+         ||+-|++------- QQQ: outer 128 KB bank (PRG A19..A17; bit 8 is A19)
+         ||  +--------- O: 0 = UNROM-like, $C000 fixed to inner bank 0 or 7
+         ||               1 = NROM: $C000 mirrors $8000 (S=0) or 32 KB bank (S=1)
+         |+------------ L: inner bank fixed at $C000 when O=0 (0 -> #0, 1 -> #7)
+         +------------- m: solder-pad menu select (submapper 1 only, ignored)
+```
+
+Implementation notes:
+
+- The 16 KB bank number is `((addr >> 2) & 0x1F) | ((addr >> 3) & 0x20)`:
+  bit 7 (O) sits between the two bank fields and must be skipped. Out of
+  range banks wrap to the image size through `prg_read`.
+- With O=0 the `$C000` bank is the outer 128 KB block's inner bank 0 (L=0)
+  or 7 (L=1); the `$8000` bank is the full number, with its low bit cleared
+  when S=1 (nesdev calls this "pointless" but it is what the board does).
+- CHR RAM is write-protected while O=1 (the multicart variant). The Chinese
+  RPG boards that keep it writable in NROM mode are not distinguished; no
+  such ROM is in `roms/`.
+- Power-on latch is 0: bank 0 at both halves, vertical mirroring, CHR RAM
+  writable. The header mirroring bit is ignored because the latch owns it.
+
+Unit tests (`tagged_rom(32, 0x4000)`, 64 banks for the A19 case) cover
+power-on state, O=0 with L=0 and L=1 across outer blocks, O=0 with S=1
+reaching only even banks, NROM-128 mirroring, NROM-256 32 KB pairs, bit 8
+as the high bank bit with bit 7 not leaking in, the latch ignoring the data
+byte and sub-`$8000` writes, mirroring from bit 1, and CHR RAM write
+protection following O.
+
+Frame dumps with the ROM: the menu ("1200 IN 1 / PUSH SEL . START BUTTON",
+twenty titles per page, cursor on entry 10) draws at frame 200 with no
+input. Select pages the list by twenty entries, Down moves the cursor one
+line, and Start launches the highlighted game (Bomberman, Galaxian). Right
+does nothing on this menu; it is not a navigation key there. The
+compatibility sweep's fixed script (Start at 150) therefore lands in
+Bomberman stage 1.
 
 ### Behaviour changes beyond CHR routing
 

--- a/docs/testing/COMPATIBILITY_SWEEP.md
+++ b/docs/testing/COMPATIBILITY_SWEEP.md
@@ -54,7 +54,7 @@ screen; that is a limit of the script, not a bug, and is noted per game.
 | river_city_ransom.nes | 4 | Cross Town High, Alex fighting two gang members | OK |
 | Tetris.nes | 1 (archaic header) | A-Type level select and high score table | OK |
 | SuperMarioBros.nes | reads as 66 | Not exercised; dirty header, use mario.nes | Skip |
-| 1200-in-1.nes | 227 | Solid blue at every checkpoint | FAIL: mapper 227 unsupported (issue 25) |
+| 1200-in-1.nes | 227 | Menu draws; script's first Start launches Bomberman, stage 1 board with enemies at 900 (paused by the later Start taps) | OK since issue 25; menu navigates with Select (page) and Down/Up (line), not Right |
 
 ## Findings
 
@@ -86,9 +86,14 @@ screen; that is a limit of the script, not a bug, and is noted per game.
   found it, comparing the top 16 rows against the rest of the frame for a
   disagreeing scroll shift, is worth keeping in mind for similar reports.
 
-- **Mapper 227 (1200-in-1 multicart)** is not implemented. The cartridge
-  loader logs "Unsupported mapper 227: falling back to NROM behaviour" and
-  the game never draws anything. Tracked in issue 25.
+- **Mapper 227 (1200-in-1 multicart)** was unimplemented at 0.8.0: the
+  loader fell back to NROM and every frame was the solid backdrop. Issue 25
+  added `src/cartridge/mapper227.rs` (see
+  docs/debugging/MAPPER_TRAIT_REFACTOR.md). The menu now draws with no
+  input, Select pages it, Down/Up move the cursor, and Start launches the
+  highlighted game; Bomberman and Galaxian both reach their title or first
+  stage. Right is not a menu key on this cart, so the sweep script simply
+  starts the default entry.
 - No rendering defect was seen in any supported game across 2400 frames of
   scripted play.
 

--- a/src/cartridge/mapper227.rs
+++ b/src/cartridge/mapper227.rs
@@ -1,0 +1,276 @@
+//! Mapper 227 (address-latch multicart, e.g. 1200-in-1).
+//!
+//! The register is the CPU address of any write to $8000-$FFFF; the data
+//! byte is ignored. Layout per nesdev "INES Mapper 227":
+//!
+//! ```text
+//! [A~1... .mLQ OQQP PpMS]
+//!          ||| |||| |||+- S: 0 = 16 KB mode (PRG A14 = p), 1 = 32 KB mode
+//!          ||| |||| ||+-- M: 0 = vertical mirroring, 1 = horizontal
+//!          ||| |||+-++--- PPp: inner 16 KB bank (PRG A16..A14)
+//!          ||+-|++------- QQQ: outer 128 KB bank (PRG A19..A17)
+//!          ||  +--------- O: 0 = $C000 fixed to inner bank L*7 (UNROM-like)
+//!          ||               1 = NROM: $C000 mirrors $8000 (S=0) or 32 KB (S=1)
+//!          |+------------ L: inner bank fixed at $C000 when O=0 (0 -> #0, 1 -> #7)
+//!          +------------- m: solder-pad menu select (submapper 1 only, ignored)
+//! ```
+//!
+//! CHR is 8 KB of unbanked RAM, write-protected while O=1 (the multicart
+//! variant; the Chinese RPG boards that leave it writable are not handled).
+//! Power-on register value is 0: bank 0 at both $8000 and $C000, vertical
+//! mirroring, CHR RAM writable.
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper227 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+    /// Last address written to $8000-$FFFF (the address latch).
+    latch: u16,
+}
+
+impl Mapper227 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, _mirroring: Mirroring) -> Self {
+        Mapper227 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            latch: 0,
+        }
+    }
+
+    fn s_32k(&self) -> bool {
+        self.latch & 0x0001 != 0
+    }
+
+    fn o_nrom(&self) -> bool {
+        self.latch & 0x0080 != 0
+    }
+
+    fn l_last(&self) -> bool {
+        self.latch & 0x0200 != 0
+    }
+
+    /// Full 16 KB bank number: inner bank (bits 2-4) plus outer bank
+    /// (bits 5-6 and bit 8), i.e. PRG A19..A14.
+    fn bank(&self) -> usize {
+        let a = self.latch as usize;
+        ((a >> 2) & 0x1F) | ((a >> 3) & 0x20)
+    }
+
+    /// 16 KB bank mapped at $8000-$BFFF.
+    fn low_bank(&self) -> usize {
+        if self.s_32k() {
+            self.bank() & !1
+        } else {
+            self.bank()
+        }
+    }
+
+    /// 16 KB bank mapped at $C000-$FFFF.
+    fn high_bank(&self) -> usize {
+        if self.o_nrom() {
+            if self.s_32k() {
+                self.bank() | 1
+            } else {
+                self.bank()
+            }
+        } else {
+            let outer = self.bank() & !7;
+            if self.l_last() {
+                outer | 7
+            } else {
+                outer
+            }
+        }
+    }
+}
+
+impl Mapper for Mapper227 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xBFFF => {
+                let offset = self.low_bank() * 0x4000 + (addr - 0x8000) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            0xC000..=0xFFFF => {
+                let offset = self.high_bank() * 0x4000 + (addr - 0xC000) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0x8000..=0xFFFF => self.latch = addr,
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read((addr & 0x1FFF) as usize)
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        if !self.o_nrom() {
+            self.chr.write((addr & 0x1FFF) as usize, value);
+        }
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        if self.latch & 0x0002 != 0 {
+            Mirroring::Horizontal
+        } else {
+            Mirroring::Vertical
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    /// 32 banks of 16 KB (512 KB), the 1200-in-1 layout.
+    fn mapper() -> Mapper227 {
+        Mapper227::new(tagged_rom(32, 0x4000), vec![], Mirroring::Horizontal)
+    }
+
+    /// Register address for the given fields (bank is the 6-bit PRG A19..A14).
+    fn reg(bank: u16, s: bool, m: bool, o: bool, l: bool) -> u16 {
+        0x8000
+            | ((bank & 0x1F) << 2)
+            | ((bank & 0x20) << 3)
+            | (s as u16)
+            | ((m as u16) << 1)
+            | ((o as u16) << 7)
+            | ((l as u16) << 9)
+    }
+
+    #[test]
+    fn power_on_maps_bank_zero_everywhere() {
+        let mut m = mapper();
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xBFFF), 0);
+        assert_eq!(m.cpu_read(0xC000), 0);
+        assert_eq!(m.cpu_read(0xFFFF), 0);
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+    }
+
+    #[test]
+    fn unrom_mode_fixes_c000_to_inner_bank_0_or_7() {
+        let mut m = mapper();
+        // O=0, L=0: switchable bank at $8000, inner bank #0 of the outer
+        // 128 KB block at $C000.
+        m.cpu_write(reg(5, false, false, false, false), 0);
+        assert_eq!(m.cpu_read(0x8000), 5);
+        assert_eq!(m.cpu_read(0xC000), 0);
+        // Outer block 1 (banks 8-15): inner bank #0 is bank 8.
+        m.cpu_write(reg(13, false, false, false, false), 0);
+        assert_eq!(m.cpu_read(0x8000), 13);
+        assert_eq!(m.cpu_read(0xC000), 8);
+        // O=0, L=1: inner bank #7 of the block is fixed at $C000.
+        m.cpu_write(reg(13, false, false, false, true), 0);
+        assert_eq!(m.cpu_read(0x8000), 13);
+        assert_eq!(m.cpu_read(0xC000), 15);
+        m.cpu_write(reg(2, false, false, false, true), 0);
+        assert_eq!(m.cpu_read(0x8000), 2);
+        assert_eq!(m.cpu_read(0xC000), 7);
+    }
+
+    #[test]
+    fn unrom_mode_with_s_set_only_reaches_even_banks() {
+        let mut m = mapper();
+        m.cpu_write(reg(11, true, false, false, true), 0);
+        assert_eq!(m.cpu_read(0x8000), 10);
+        assert_eq!(m.cpu_read(0xC000), 15);
+    }
+
+    #[test]
+    fn nrom128_mode_mirrors_the_16k_bank() {
+        let mut m = mapper();
+        m.cpu_write(reg(9, false, false, true, false), 0);
+        assert_eq!(m.cpu_read(0x8000), 9);
+        assert_eq!(m.cpu_read(0xBFFF), 9);
+        assert_eq!(m.cpu_read(0xC000), 9);
+        assert_eq!(m.cpu_read(0xFFFF), 9);
+        // L is ignored when O=1.
+        m.cpu_write(reg(9, false, false, true, true), 0);
+        assert_eq!(m.cpu_read(0xC000), 9);
+    }
+
+    #[test]
+    fn nrom256_mode_maps_32k_bank() {
+        let mut m = mapper();
+        // Bank 9 in 32 KB mode: the low bit is dropped, giving banks 8 and 9.
+        m.cpu_write(reg(9, true, false, true, false), 0);
+        assert_eq!(m.cpu_read(0x8000), 8);
+        assert_eq!(m.cpu_read(0xC000), 9);
+        m.cpu_write(reg(30, true, false, true, true), 0);
+        assert_eq!(m.cpu_read(0x8000), 30);
+        assert_eq!(m.cpu_read(0xFFFF), 31);
+    }
+
+    #[test]
+    fn bit_8_is_the_high_bank_bit() {
+        // 64 banks so bit 8 (PRG A19) selects a real bank.
+        let mut m = Mapper227::new(tagged_rom(64, 0x4000), vec![], Mirroring::Horizontal);
+        m.cpu_write(reg(0x23, false, false, true, false), 0);
+        assert_eq!(m.cpu_read(0x8000), 0x23);
+        // Bit 7 (O) sits between the two bank fields and must not leak in.
+        m.cpu_write(reg(0x03, false, false, true, false), 0);
+        assert_eq!(m.cpu_read(0x8000), 0x03);
+        // On a 512 KB image bit 8 wraps to the ROM size.
+        let mut m = mapper();
+        m.cpu_write(reg(0x23, false, false, true, false), 0);
+        assert_eq!(m.cpu_read(0x8000), 0x03);
+    }
+
+    #[test]
+    fn latch_ignores_data_and_takes_any_address() {
+        let mut m = mapper();
+        // Bits 10-14 (m and the unused address lines) do not affect banking.
+        m.cpu_write(reg(4, false, false, true, false) | 0x7C00, 0xFF);
+        assert_eq!(m.cpu_read(0x8000), 4);
+        // Writes below $8000 do not touch the latch.
+        m.cpu_write(0x7FFF, 0);
+        assert_eq!(m.cpu_read(0x8000), 4);
+        assert_eq!(m.cpu_read(0x7FFF), 0);
+    }
+
+    #[test]
+    fn mirroring_follows_bit_1() {
+        let mut m = mapper();
+        m.cpu_write(reg(0, false, true, false, false), 0);
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+        m.cpu_write(reg(0, false, false, false, false), 0);
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+    }
+
+    #[test]
+    fn chr_ram_write_protected_while_o_set() {
+        let mut m = mapper();
+        m.ppu_write(0x0010, 0x11);
+        assert_eq!(m.ppu_read(0x0010), 0x11);
+        // O=1 (NROM modes): writes are ignored, reads still work.
+        m.cpu_write(reg(0, false, false, true, false), 0);
+        m.ppu_write(0x0010, 0x22);
+        assert_eq!(m.ppu_read(0x0010), 0x11);
+        m.cpu_write(reg(0, true, false, true, false), 0);
+        m.ppu_write(0x0010, 0x33);
+        assert_eq!(m.ppu_read(0x0010), 0x11);
+        // Back to O=0: writable again.
+        m.cpu_write(reg(0, false, false, false, false), 0);
+        m.ppu_write(0x0010, 0x44);
+        assert_eq!(m.ppu_read(0x0010), 0x44);
+    }
+}

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -8,6 +8,7 @@ pub mod mapper;
 pub mod mapper0;
 pub mod mapper1;
 pub mod mapper2;
+pub mod mapper227;
 pub mod mapper3;
 pub mod mapper4;
 pub mod mapper5;
@@ -138,6 +139,7 @@ impl Cartridge {
             4 => Box::new(mapper4::Mapper4::new(prg_rom, chr_rom, mirroring)),
             5 => Box::new(mapper5::Mapper5::new(prg_rom, chr_rom, mirroring)),
             65 => Box::new(mapper65::Mapper65::new(prg_rom, chr_rom, mirroring)),
+            227 => Box::new(mapper227::Mapper227::new(prg_rom, chr_rom, mirroring)),
             other => {
                 log::warn!(
                     "Unsupported mapper {}: falling back to NROM behaviour",


### PR DESCRIPTION
## Summary

Implements iNES mapper 227 (address-latch multicart) so `roms/1200-in-1.nes` draws its menu instead of falling back to NROM. Closes #25.

- `src/cartridge/mapper227.rs`: the CPU address of any write to `$8000-$FFFF` is the latch. Bank number is `((addr >> 2) & 0x1F) | ((addr >> 3) & 0x20)` (bits 2-6 plus bit 8 as PRG A19; bit 7 sits between the fields and is skipped). S (bit 0) selects 32 KB mode, M (bit 1) selects horizontal/vertical mirroring, O (bit 7) selects the NROM modes; with O=0 the `$C000` bank is fixed to inner bank 0 (L=0) or 7 (L=1) of the current 128 KB block. CHR RAM is write-protected while O=1. Power-on latch is 0. Taken from the raw nesdev "INES Mapper 227" table rather than the issue's summary.
- `src/cartridge/mod.rs`: `227 =>` arm and module declaration only. `mapper.rs` untouched.
- Docs: new "Mapper 227" section in `docs/debugging/MAPPER_TRAIT_REFACTOR.md`; 1200-in-1 row and finding updated in `docs/testing/COMPATIBILITY_SWEEP.md`.

## Unit tests (9, tagged synthetic PRG of 32 x 16 KB; 64 banks for the A19 case)

- power-on: bank 0 at both `$8000` and `$C000`, vertical mirroring
- O=0, L=0: switchable `$8000` bank, `$C000` fixed to inner bank 0 of the outer block (checked across blocks 0 and 1)
- O=0, L=1: `$C000` fixed to inner bank 7 of the outer block
- O=0, S=1: `$8000` only reaches even banks
- O=1, S=0 (NROM-128): `$C000` mirrors `$8000`, L ignored
- O=1, S=1 (NROM-256): 32 KB pair, low bit dropped
- bit 8 is the high bank bit; bit 7 does not leak into the bank; wraps on a 512 KB image
- latch ignores the data byte and bits 10-14; writes below `$8000` do not touch it
- mirroring follows bit 1
- CHR RAM writable with O=0, write-protected in both O=1 modes, writable again after O clears

## Frame dumps with the ROM

Sweep (`cargo test --release --test game_sweep -- --ignored`) plus a scratch harness with a controlled script, frames converted with the stdlib PNG script and viewed:

- Frame 200, no input: the menu draws. Title "1200 IN 1", "PUSH SEL . START BUTTON", twenty entries (1. CONTRA, 2. CHINESE CHESE, ... 10. BOMBMAN ... 20. ATOM 2), cursor on entry 10.
- Select twice: the list pages to entries 41-60 with the cursor on 50 "BIRDIE 3"; Start launched Galaxian (a renamed duplicate on this cart).
- Down twice: cursor moves 10 to 12 "GALAXIAN"; Start launched the Galaxian title screen.
- Up twice: cursor moves 10 to 8 "CIRCUSE"; Start launched the Circus Charlie play-select screen.
- Sweep script (Start at 150): Bomberman stage 1 board with enemies at frame 900, then paused by the later Start taps.

Right does not move the selection: this menu navigates with Select (page) and Up/Down (line), which corrects the assumption in the issue. Three different highlighted entries launched three different games, so the outer-bank selection is exercised.

## Checks

`cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all pass. Commit is GPG-signed. No ROMs committed.
