### PR TITLE
feat(cheat): Game Genie and raw code cheat engine in the library

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Contains debugging session notes and references:
 - `PPU_SPRITE_PIPELINE.md` - Per-dot sprite evaluation and fetch, overflow scan bug, sprite 0 hit rules, 8-pixel background shift fix, MMC3 A12 dot timing (#11)
 - `TETRIS_MMC1_FIX.md` - Tetris garbled tiles traced to an archaic DiskDude iNES header read as mapper 65; header sanitising in the cartridge loader (#22)
 - `BATTERY_SAVES.md` - Battery-backed PRG RAM persisted to a .sav file next to the ROM; Mapper prg_ram accessors, System::load_battery/save_battery, hash-based dirty flush (#26)
+- `CHEAT_ENGINE.md` - Game Genie and raw code decoding, ROM-read and per-frame RAM-freeze hooks in System, .cht file format, headless SMB SXIOPO proof (#31)
 
 ### `/plans/`
 Contains implementation plans and roadmaps:

--- a/docs/debugging/CHEAT_ENGINE.md
+++ b/docs/debugging/CHEAT_ENGINE.md
@@ -1,0 +1,179 @@
+# Cheat Engine: Game Genie and Raw Codes in the Library
+
+**Date:** 2026-09-05
+**Type:** Feature
+**Issue:** #31 (Phase 2 of docs/plans/TOOLS_AND_CHEATS.md)
+**Status:** Complete
+
+## Executive Summary
+
+`src/cheat.rs` decodes Game Genie codes and raw address/value codes into
+two kinds of cheat, and `System` applies them at two hook points: ROM
+patches intercept CPU reads of `$8000-$FFFF`, RAM freezes are poked once
+per frame. The set is persisted as a `.cht` text file next to the ROM.
+The library stays UI-free; the tool page and palette commands are issue
+#32.
+
+## Code formats
+
+All input is upper-cased and stripped of whitespace and dashes before
+decoding, so `sxi-opo`, `SXIOPO` and `sxi opo` are the same code.
+
+| Form          | Example        | Meaning                                              |
+|---------------|----------------|------------------------------------------------------|
+| 6 letters     | `SXIOPO`       | ROM patch, no compare byte                           |
+| 8 letters     | `GZUXNGEI`     | ROM patch with compare byte                          |
+| `AAAA:VV`     | `075A:02`      | RAM freeze when AAAA < `$8000`, else ROM patch       |
+| `AAAA?CC:VV`  | `91D9?CE:AD`   | ROM patch that only applies when the ROM byte is CC |
+
+Game Genie letters and their values: `A P Z L G I T Y E O X U K S V N`
+= 0 to 15. Any other letter is `CheatError::BadLetter`; lengths other
+than 6 or 8 are `CheatError::BadLength`.
+
+### Game Genie decoding
+
+With `n0..n7` the values of the letters in order (nesdev wiki, nesgg.txt):
+
+```text
+address = 0x8000 | (n3&7)<<12 | (n5&7)<<8 | (n4&8)<<8
+                 | (n2&7)<<4  | (n1&8)<<4 | (n4&7) | (n3&8)
+value   = (n1&7)<<4 | (n0&8)<<4 | (n0&7) | (n5&8)      6 letters
+value   = (n1&7)<<4 | (n0&8)<<4 | (n0&7) | (n7&8)      8 letters
+compare = (n7&7)<<4 | (n6&8)<<4 | (n6&7) | (n5&8)      8 letters
+```
+
+The address only ever uses letters 2 to 6, so an 8-letter code and its
+first six letters patch the same address. Bit 3 of the third letter is
+set in 8-letter codes and clear in 6-letter ones; the decoder does not
+enforce it (it uses the length), but the unit tests check the documented
+examples agree.
+
+Worked example, `SXIOPO` (Super Mario Bros infinite lives):
+
+```text
+S=13 X=10 I=5 O=9 P=1 O=9
+address = 0x8000 | 1<<12 | 1<<8 | 0 | 5<<4 | 8<<4 | 1 | 8 = 0x91D9
+value   = 2<<4 | 8<<4 | 5 | 8 = 0xAD
+```
+
+nesgg.txt lists the same result. Checking the ROM confirms the mechanism:
+`$91D9` in mario.nes holds `CE 5A 07` (`DEC $075A`, the lives decrement
+in the player-death routine); `$AD` turns it into `LDA $075A`, a harmless
+load with the same operand bytes.
+
+`GZUXNGEI` decodes to `$AC3F`, value `$24`, compare `$D0`. Neither
+source we could reach carries a decoded value for it, so the unit tests
+verify it by round-tripping through an encoder (the inverse bit layout)
+and by checking its address equals that of `GZUXNG`.
+
+## Hook points
+
+### ROM patches: `System::bus_read`
+
+The `$4020-$FFFF` arm reads the byte from the mapper first (compare needs
+the real byte and mapper side effects must still happen), then, only when
+`CheatSet::is_active()` and `addr >= 0x8000`, calls
+`CheatSet::rom_override(addr, value)`. ROM patches therefore only ever
+apply to reads at `$8000` and above: an `AAAA?CC:VV` code with AAAA below
+`$8000` parses as a ROM patch but never fires. `is_active` is a bool maintained by
+every mutating `CheatSet` method ("any cheat enabled"), so with no cheats
+the hot path costs one load and one branch. `read_byte` itself is
+untouched. `peek` bypasses cheats on purpose: tools and tests can still
+see the real ROM byte.
+
+The first enabled cheat whose address matches, and whose compare byte (if
+any) equals the real byte, wins.
+
+### RAM freezes: start of `System::run_frame_with_audio`
+
+`apply_ram_freezes` collects the enabled freezes and pokes each through
+`System::poke`, once per frame before the first instruction. Because
+`poke` only reaches CPU RAM (`$0000-$1FFF`) and PRG RAM (`$6000-$7FFF`), a
+freeze in `$2000-$5FFF` is a silent no-op. Freezing once per frame is what
+Game Genie style RAM codes on other emulators do; a value the game rewrites
+mid-frame is restored before the next frame's logic runs, which is enough
+for counters that only matter at the frame boundary.
+
+## API
+
+```rust
+let mut cheat = Cheat::parse("SXIOPO")?;       // enabled, empty description
+cheat.description = "Infinite lives".into();
+let idx = system.cheats_mut().add(cheat);
+system.cheats_mut().toggle(idx);               // returns the new state
+system.cheats_mut().remove(idx);
+system.cheats().is_active();
+system.load_cheats(&path)?;                    // Ok(false) if no file
+system.save_cheats(&path)?;
+```
+
+`CheatSet` also implements `Display` (the `.cht` text) and `FromStr`.
+
+## `.cht` file format
+
+One cheat per line, tab separated: `CODE<TAB>1|0<TAB>description`. The
+enabled flag and description are optional. Blank lines and lines starting
+with `#` are ignored. `Display` writes a comment header first.
+
+```text
+# nes-emu cheats: CODE<TAB>1|0<TAB>description
+SXIOPO	1	Infinite lives
+075A:02	0	Freeze lives at 3
+```
+
+`load_cheats` replaces the whole set; a malformed line is reported as an
+`InvalidData` error naming the line number and leaves the set untouched.
+`save_cheats` always writes, even an empty set, so a cleared list does not
+come back on the next load.
+
+## Verification
+
+Unit tests in `src/cheat.rs`: `SXIOPO` decodes to `$91D9:$AD`; case and
+separator insensitivity; the 8-letter example; 500 random
+address/value/compare triples encoded and decoded back; bad letters,
+lengths and raw forms rejected; `rom_override` compare and enable
+semantics; freezes skip disabled cheats; `.cht` round trip, comment
+handling and line-numbered errors.
+
+Unit tests in `src/system/tests.rs` drive the real CPU: `LDA #$11` at the
+reset vector with a cheat on `$8001` loads `$22` (and `peek` still shows
+`$11`); a compare mismatch leaves `$11`; a disabled cheat leaves `$11`; a
+RAM freeze is reapplied at the next `run_frame` after a poke; the file
+round trip through `System::save_cheats`/`load_cheats`, including the
+missing-file and malformed-file cases.
+
+### Headless Super Mario Bros run (`tests/cheats_smb.rs`, ignored)
+
+```text
+cargo test --release --test cheats_smb -- --ignored --nocapture
+```
+
+Two runs of the same input script (Start tapped at frame 150, Right held
+from frame 300 so Mario walks into the first Goomba), watching `$075A`
+(lives minus one, 2 at the start of a game):
+
+```text
+control: frame 720: $075A 02 -> 01
+control: ran 842 frames, $075A at frame 300 02, final 01
+sxiopo: ran 2400 frames, $075A at frame 300 02, final 02
+```
+
+Without the cheat the counter drops at frame 720 when the death sequence
+finishes. With `SXIOPO`, under identical input, `$075A` stayed `02` for
+all 2400 frames. The test measures only the counter, not the deaths
+themselves; the identical script and the frame-720 drop in the control
+run are what show a death was staged. The test also asserts the real
+bytes at `$91D9` are `CE 5A 07` before patching.
+
+Empty-set cost: the existing nestest and blargg suites are unchanged with
+the hook in place (see the PR for the run).
+
+## Debugging notes
+
+- A first attempt at the SMB test measured `$075A` from power-on and
+  stopped two seconds after the first change. It stopped at frame 153:
+  SMB writes `$075A` (0 to 2) at frame 31 during title-screen init, long
+  before Start. The trace now starts at the frame Right is pressed.
+- `"91D9"` with no colon is parsed as a Game Genie code and fails on the
+  letter `9`, not as a malformed raw code. That is intended: anything
+  without `:` is treated as Game Genie.

--- a/src/cheat.rs
+++ b/src/cheat.rs
@@ -1,0 +1,590 @@
+//! Cheat engine: Game Genie codes and raw address/value cheats
+//! (docs/debugging/CHEAT_ENGINE.md, issue #31).
+//!
+//! Two kinds of cheat exist:
+//!
+//! - **ROM patches** intercept CPU reads in `$8000-$FFFF`. When the address
+//!   matches (and, if the cheat carries a compare byte, the byte the mapper
+//!   returned equals it) the cheat value is returned instead. This is
+//!   exactly what a Game Genie cartridge does in hardware.
+//! - **RAM freezes** poke a value into RAM once per frame, so a counter the
+//!   game decrements is put back before the next frame's logic runs.
+//!
+//! The `System` bus hook checks [`CheatSet::is_active`] first, a single
+//! bool load, so an empty or fully disabled set costs nothing on the hot
+//! read path.
+
+use std::fmt;
+use std::str::FromStr;
+use thiserror::Error;
+
+/// Game Genie alphabet. The index of each letter is its 4-bit value.
+pub const GAME_GENIE_LETTERS: &[u8; 16] = b"APZLGITYEOXUKSVN";
+
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
+pub enum CheatError {
+    #[error("empty cheat code")]
+    Empty,
+    #[error("invalid Game Genie letter '{0}' (valid: APZLGITYEOXUKSVN)")]
+    BadLetter(char),
+    #[error("Game Genie codes are 6 or 8 letters, got {0}")]
+    BadLength(usize),
+    #[error("malformed raw code '{0}' (expected AAAA:VV or AAAA?CC:VV)")]
+    BadRaw(String),
+    #[error("line {line}: {source}")]
+    Line {
+        line: usize,
+        #[source]
+        source: Box<CheatError>,
+    },
+}
+
+/// What a cheat does once decoded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheatKind {
+    /// Override a PRG ROM read at `addr` (`$8000-$FFFF`). With `compare`
+    /// set, only when the real byte equals it.
+    Rom {
+        addr: u16,
+        value: u8,
+        compare: Option<u8>,
+    },
+    /// Write `value` to `addr` at the start of every frame.
+    RamFreeze { addr: u16, value: u8 },
+}
+
+impl CheatKind {
+    /// Compact raw-code rendering (`AAAA:VV` or `AAAA?CC:VV`).
+    pub fn raw_code(&self) -> String {
+        match *self {
+            CheatKind::Rom {
+                addr,
+                value,
+                compare: Some(cmp),
+            } => format!("{addr:04X}?{cmp:02X}:{value:02X}"),
+            CheatKind::Rom { addr, value, .. } | CheatKind::RamFreeze { addr, value } => {
+                format!("{addr:04X}:{value:02X}")
+            }
+        }
+    }
+}
+
+/// One cheat as the user entered it, plus its decoded effect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cheat {
+    /// Normalised code text: upper case, no whitespace or dashes.
+    pub code: String,
+    pub description: String,
+    pub enabled: bool,
+    pub kind: CheatKind,
+}
+
+/// Upper-case the code and drop whitespace and dashes.
+fn normalise(code: &str) -> String {
+    code.chars()
+        .filter(|c| !c.is_whitespace() && *c != '-')
+        .map(|c| c.to_ascii_uppercase())
+        .collect()
+}
+
+fn letter_value(c: char) -> Result<u8, CheatError> {
+    GAME_GENIE_LETTERS
+        .iter()
+        .position(|&l| l as char == c)
+        .map(|v| v as u8)
+        .ok_or(CheatError::BadLetter(c))
+}
+
+/// Decode a normalised 6 or 8 letter Game Genie code.
+///
+/// Bit layout (nesdev, nesgg.txt), with `n[i]` the value of letter `i`:
+///
+/// ```text
+/// address = 0x8000 | (n3&7)<<12 | (n5&7)<<8 | (n4&8)<<8
+///                  | (n2&7)<<4  | (n1&8)<<4 | (n4&7) | (n3&8)
+/// value   = (n1&7)<<4 | (n0&8)<<4 | (n0&7) | (n5&8)      6 letters
+/// value   = (n1&7)<<4 | (n0&8)<<4 | (n0&7) | (n7&8)      8 letters
+/// compare = (n7&7)<<4 | (n6&8)<<4 | (n6&7) | (n5&8)      8 letters
+/// ```
+///
+/// Bit 3 of the third letter is set in 8-letter codes and clear in
+/// 6-letter ones; it is informational and not checked here.
+fn decode_game_genie(code: &str) -> Result<CheatKind, CheatError> {
+    let n: Vec<u16> = code
+        .chars()
+        .map(|c| letter_value(c).map(u16::from))
+        .collect::<Result<_, _>>()?;
+    if n.len() != 6 && n.len() != 8 {
+        return Err(CheatError::BadLength(n.len()));
+    }
+    let addr = 0x8000
+        | ((n[3] & 7) << 12)
+        | ((n[5] & 7) << 8)
+        | ((n[4] & 8) << 8)
+        | ((n[2] & 7) << 4)
+        | ((n[1] & 8) << 4)
+        | (n[4] & 7)
+        | (n[3] & 8);
+    let value_hi = ((n[1] & 7) << 4) | ((n[0] & 8) << 4) | (n[0] & 7);
+    if n.len() == 6 {
+        let value = (value_hi | (n[5] & 8)) as u8;
+        Ok(CheatKind::Rom {
+            addr,
+            value,
+            compare: None,
+        })
+    } else {
+        let value = (value_hi | (n[7] & 8)) as u8;
+        let compare = (((n[7] & 7) << 4) | ((n[6] & 8) << 4) | (n[6] & 7) | (n[5] & 8)) as u8;
+        Ok(CheatKind::Rom {
+            addr,
+            value,
+            compare: Some(compare),
+        })
+    }
+}
+
+/// Decode a normalised raw code: `AAAA:VV` or `AAAA?CC:VV`.
+fn decode_raw(code: &str) -> Result<CheatKind, CheatError> {
+    let bad = || CheatError::BadRaw(code.to_string());
+    let (lhs, value) = code.split_once(':').ok_or_else(bad)?;
+    let (addr, compare) = match lhs.split_once('?') {
+        Some((a, c)) => (a, Some(c)),
+        None => (lhs, None),
+    };
+    let parse_u16 = |s: &str| {
+        if s.len() == 4 {
+            u16::from_str_radix(s, 16).ok()
+        } else {
+            None
+        }
+    };
+    let parse_u8 = |s: &str| {
+        if s.len() == 2 {
+            u8::from_str_radix(s, 16).ok()
+        } else {
+            None
+        }
+    };
+    let addr = parse_u16(addr).ok_or_else(bad)?;
+    let value = parse_u8(value).ok_or_else(bad)?;
+    let compare = match compare {
+        Some(c) => Some(parse_u8(c).ok_or_else(bad)?),
+        None => None,
+    };
+    if compare.is_none() && addr < 0x8000 {
+        Ok(CheatKind::RamFreeze { addr, value })
+    } else {
+        Ok(CheatKind::Rom {
+            addr,
+            value,
+            compare,
+        })
+    }
+}
+
+impl Cheat {
+    /// Parse a Game Genie code (6 or 8 letters) or a raw code (`AAAA:VV`,
+    /// `AAAA?CC:VV`). Case-insensitive; whitespace and dashes are ignored.
+    ///
+    /// Raw codes below `$8000` without a compare byte become RAM freezes;
+    /// everything else is a ROM patch.
+    pub fn parse(code: &str) -> Result<Cheat, CheatError> {
+        let code = normalise(code);
+        if code.is_empty() {
+            return Err(CheatError::Empty);
+        }
+        let kind = if code.contains(':') {
+            decode_raw(&code)?
+        } else {
+            decode_game_genie(&code)?
+        };
+        Ok(Cheat {
+            code,
+            description: String::new(),
+            enabled: true,
+            kind,
+        })
+    }
+
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = description.into();
+        self
+    }
+}
+
+/// An ordered collection of cheats with a cached "anything enabled" flag.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CheatSet {
+    cheats: Vec<Cheat>,
+    /// True when at least one cheat is enabled. Recomputed by every
+    /// mutating method so the bus hook only ever tests this bool.
+    active: bool,
+}
+
+impl CheatSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn refresh(&mut self) {
+        self.active = self.cheats.iter().any(|c| c.enabled);
+    }
+
+    /// True when at least one cheat is enabled.
+    #[inline]
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn len(&self) -> usize {
+        self.cheats.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.cheats.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Cheat> {
+        self.cheats.iter()
+    }
+
+    pub fn get(&self, index: usize) -> Option<&Cheat> {
+        self.cheats.get(index)
+    }
+
+    /// Append a cheat and return its index.
+    pub fn add(&mut self, cheat: Cheat) -> usize {
+        self.cheats.push(cheat);
+        self.refresh();
+        self.cheats.len() - 1
+    }
+
+    /// Remove the cheat at `index`, if any.
+    pub fn remove(&mut self, index: usize) -> Option<Cheat> {
+        if index >= self.cheats.len() {
+            return None;
+        }
+        let cheat = self.cheats.remove(index);
+        self.refresh();
+        Some(cheat)
+    }
+
+    /// Flip the enabled flag of the cheat at `index`. Returns the new
+    /// state, or `None` when the index is out of range.
+    pub fn toggle(&mut self, index: usize) -> Option<bool> {
+        let cheat = self.cheats.get_mut(index)?;
+        cheat.enabled = !cheat.enabled;
+        let enabled = cheat.enabled;
+        self.refresh();
+        Some(enabled)
+    }
+
+    pub fn set_enabled(&mut self, index: usize, enabled: bool) -> Option<()> {
+        self.cheats.get_mut(index)?.enabled = enabled;
+        self.refresh();
+        Some(())
+    }
+
+    pub fn set_description(&mut self, index: usize, description: impl Into<String>) -> Option<()> {
+        self.cheats.get_mut(index)?.description = description.into();
+        Some(())
+    }
+
+    pub fn clear(&mut self) {
+        self.cheats.clear();
+        self.active = false;
+    }
+
+    /// Value a CPU read of `addr` should return given that the cartridge
+    /// returned `rom_value`, or `None` when no enabled ROM cheat applies.
+    /// The first matching cheat wins.
+    pub fn rom_override(&self, addr: u16, rom_value: u8) -> Option<u8> {
+        if !self.active {
+            return None;
+        }
+        self.cheats.iter().find_map(|c| match c.kind {
+            CheatKind::Rom {
+                addr: a,
+                value,
+                compare,
+            } if c.enabled && a == addr && compare.is_none_or(|cmp| cmp == rom_value) => {
+                Some(value)
+            }
+            _ => None,
+        })
+    }
+
+    /// Call `poke(addr, value)` for every enabled RAM freeze, in order.
+    pub fn apply_ram_freezes(&self, mut poke: impl FnMut(u16, u8)) {
+        if !self.active {
+            return;
+        }
+        for c in &self.cheats {
+            if let CheatKind::RamFreeze { addr, value } = c.kind {
+                if c.enabled {
+                    poke(addr, value);
+                }
+            }
+        }
+    }
+
+    /// Parse the `.cht` text format: one cheat per line as
+    /// `CODE<TAB>1|0<TAB>description`; blank lines and lines starting with
+    /// `#` are ignored. The enabled flag and description are optional.
+    pub fn parse(text: &str) -> Result<CheatSet, CheatError> {
+        let mut set = CheatSet::new();
+        for (i, line) in text.lines().enumerate() {
+            let line = line.trim_end_matches('\r');
+            if line.trim().is_empty() || line.trim_start().starts_with('#') {
+                continue;
+            }
+            let mut fields = line.splitn(3, '\t');
+            let code = fields.next().unwrap_or("");
+            let enabled = fields.next().map(str::trim).unwrap_or("1");
+            let description = fields.next().unwrap_or("").trim().to_string();
+            let mut cheat = Cheat::parse(code).map_err(|e| CheatError::Line {
+                line: i + 1,
+                source: Box::new(e),
+            })?;
+            cheat.enabled = enabled != "0";
+            cheat.description = description;
+            set.cheats.push(cheat);
+        }
+        set.refresh();
+        Ok(set)
+    }
+}
+
+impl fmt::Display for CheatSet {
+    /// Render the `.cht` text format accepted by [`CheatSet::parse`].
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "# nes-emu cheats: CODE<TAB>1|0<TAB>description")?;
+        for c in &self.cheats {
+            writeln!(f, "{}\t{}\t{}", c.code, u8::from(c.enabled), c.description)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for CheatSet {
+    type Err = CheatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        CheatSet::parse(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Inverse of `decode_game_genie`, used to round-trip arbitrary
+    /// address/value/compare triples through the decoder.
+    fn encode(addr: u16, value: u8, compare: Option<u8>) -> String {
+        let a = addr;
+        let v = value as u16;
+        let mut n = [0u16; 8];
+        n[0] = ((v >> 4) & 8) | (v & 7);
+        n[1] = ((v >> 4) & 7) | ((a >> 4) & 8);
+        n[2] = ((a >> 4) & 7) | if compare.is_some() { 8 } else { 0 };
+        n[3] = ((a >> 12) & 7) | (a & 8);
+        n[4] = (a & 7) | ((a >> 8) & 8);
+        match compare {
+            None => {
+                n[5] = ((a >> 8) & 7) | (v & 8);
+                n[..6]
+                    .iter()
+                    .map(|&x| GAME_GENIE_LETTERS[x as usize] as char)
+                    .collect()
+            }
+            Some(c) => {
+                let c = c as u16;
+                n[5] = ((a >> 8) & 7) | (c & 8);
+                n[6] = ((c >> 4) & 8) | (c & 7);
+                n[7] = ((c >> 4) & 7) | (v & 8);
+                n.iter()
+                    .map(|&x| GAME_GENIE_LETTERS[x as usize] as char)
+                    .collect()
+            }
+        }
+    }
+
+    fn rom(code: &str) -> (u16, u8, Option<u8>) {
+        match Cheat::parse(code).unwrap().kind {
+            CheatKind::Rom {
+                addr,
+                value,
+                compare,
+            } => (addr, value, compare),
+            other => panic!("{code}: expected ROM cheat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sxiopo_decodes_to_smb_infinite_lives() {
+        // Documented in nesgg.txt: SXIOPO patches $91D9 (DEC $075A) to
+        // $AD (LDA $075A). Verified against the SMB ROM in
+        // tests/cheats_smb.rs.
+        assert_eq!(rom("SXIOPO"), (0x91D9, 0xAD, None));
+    }
+
+    #[test]
+    fn game_genie_is_case_and_separator_insensitive() {
+        assert_eq!(rom("sxi-opo"), (0x91D9, 0xAD, None));
+        assert_eq!(rom(" sx io po "), (0x91D9, 0xAD, None));
+        assert_eq!(Cheat::parse("sxi-opo").unwrap().code, "SXIOPO");
+    }
+
+    #[test]
+    fn eight_letter_code_carries_compare() {
+        let (addr, value, compare) = rom("GZUXNGEI");
+        assert_eq!(addr, 0xAC3F);
+        assert_eq!(value, 0x24);
+        assert_eq!(compare, Some(0xD0));
+        // The address never depends on letters 7 and 8.
+        let (addr6, ..) = rom("GZUXNG");
+        assert_eq!(addr6, addr);
+    }
+
+    #[test]
+    fn third_letter_bit3_flags_code_length() {
+        // Not enforced by the decoder, but a consistency check on the
+        // documented examples.
+        assert_eq!(letter_value('I').unwrap() & 8, 0); // SXIOPO
+        assert_eq!(letter_value('U').unwrap() & 8, 8); // GZUXNGEI
+    }
+
+    #[test]
+    fn game_genie_round_trips_through_encoder() {
+        assert_eq!(encode(0x91D9, 0xAD, None), "SXIOPO");
+        assert_eq!(encode(0xAC3F, 0x24, Some(0xD0)), "GZUXNGEI");
+        let mut seed: u32 = 0x1234_5678;
+        for _ in 0..500 {
+            seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            let addr = 0x8000 | (seed >> 17) as u16 & 0x7FFF;
+            let value = (seed >> 8) as u8;
+            let compare = if seed & 1 == 1 {
+                Some((seed >> 3) as u8)
+            } else {
+                None
+            };
+            let code = encode(addr, value, compare);
+            assert_eq!(code.len(), if compare.is_some() { 8 } else { 6 });
+            assert_eq!(rom(&code), (addr, value, compare), "code {code}");
+        }
+    }
+
+    #[test]
+    fn game_genie_rejects_bad_input() {
+        assert_eq!(Cheat::parse(""), Err(CheatError::Empty));
+        assert_eq!(Cheat::parse("SXIOP"), Err(CheatError::BadLength(5)));
+        assert_eq!(Cheat::parse("SXIOPOA"), Err(CheatError::BadLength(7)));
+        assert_eq!(Cheat::parse("SXIOPB"), Err(CheatError::BadLetter('B')));
+    }
+
+    #[test]
+    fn raw_codes() {
+        assert_eq!(
+            Cheat::parse("075a:02").unwrap().kind,
+            CheatKind::RamFreeze {
+                addr: 0x075A,
+                value: 0x02
+            }
+        );
+        assert_eq!(rom("91D9:AD"), (0x91D9, 0xAD, None));
+        assert_eq!(rom("91d9?ce:ad"), (0x91D9, 0xAD, Some(0xCE)));
+        // A compare byte forces a ROM patch even below $8000.
+        assert_eq!(rom("6000?01:02"), (0x6000, 0x02, Some(0x01)));
+        for bad in ["91D9:", ":AD", "91D9:ADD", "9D9:AD", "91D9?C:AD", "ZZZZ:00"] {
+            assert!(
+                matches!(Cheat::parse(bad), Err(CheatError::BadRaw(_))),
+                "{bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn rom_override_respects_compare_and_enabled() {
+        let mut set = CheatSet::new();
+        assert!(!set.is_active());
+        assert_eq!(set.rom_override(0x91D9, 0xCE), None);
+
+        set.add(Cheat::parse("91D9?CE:AD").unwrap());
+        assert!(set.is_active());
+        assert_eq!(set.rom_override(0x91D9, 0xCE), Some(0xAD));
+        assert_eq!(set.rom_override(0x91D9, 0xCF), None, "compare mismatch");
+        assert_eq!(set.rom_override(0x91DA, 0xCE), None, "other address");
+
+        set.toggle(0);
+        assert!(!set.is_active());
+        assert_eq!(set.rom_override(0x91D9, 0xCE), None, "disabled");
+        set.toggle(0);
+        assert_eq!(set.rom_override(0x91D9, 0xCE), Some(0xAD));
+
+        set.remove(0);
+        assert!(set.is_empty());
+        assert!(!set.is_active());
+    }
+
+    #[test]
+    fn ram_freezes_only_enabled_ones() {
+        let mut set = CheatSet::new();
+        set.add(Cheat::parse("0010:42").unwrap());
+        set.add(Cheat::parse("0011:43").unwrap());
+        set.add(Cheat::parse("SXIOPO").unwrap());
+        set.set_enabled(1, false);
+        let mut pokes = Vec::new();
+        set.apply_ram_freezes(|a, v| pokes.push((a, v)));
+        assert_eq!(pokes, vec![(0x0010, 0x42)]);
+    }
+
+    #[test]
+    fn cht_round_trip() {
+        let mut set = CheatSet::new();
+        set.add(
+            Cheat::parse("SXIOPO")
+                .unwrap()
+                .with_description("Infinite lives"),
+        );
+        set.add(Cheat::parse("075a:02").unwrap());
+        set.add(
+            Cheat::parse("gzuxngei")
+                .unwrap()
+                .with_description("With compare"),
+        );
+        set.set_enabled(1, false);
+
+        let text = set.to_string();
+        assert!(text.starts_with('#'));
+        assert!(text.contains("SXIOPO\t1\tInfinite lives\n"));
+        assert!(text.contains("075A:02\t0\t\n"));
+        assert!(text.contains("GZUXNGEI\t1\tWith compare\n"));
+
+        let back: CheatSet = text.parse().unwrap();
+        assert_eq!(back, set);
+        assert!(back.is_active());
+    }
+
+    #[test]
+    fn cht_parse_tolerates_comments_and_missing_fields() {
+        let text = "# comment\n\nSXIOPO\r\n91D9:AD\t0\n  # indented comment\n";
+        let set = CheatSet::parse(text).unwrap();
+        assert_eq!(set.len(), 2);
+        assert!(set.get(0).unwrap().enabled);
+        assert!(!set.get(1).unwrap().enabled);
+        assert_eq!(set.get(1).unwrap().description, "");
+    }
+
+    #[test]
+    fn cht_parse_reports_line_number() {
+        let err = CheatSet::parse("SXIOPO\n\nBOGUS\n").unwrap_err();
+        match err {
+            CheatError::Line { line, source } => {
+                assert_eq!(line, 3);
+                assert_eq!(*source, CheatError::BadLetter('B'));
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod apu;
 pub mod cartridge;
+pub mod cheat;
 pub mod input;
 pub mod ppu;
 pub mod system;

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,5 +1,6 @@
 use crate::apu::Apu;
 use crate::cartridge::{Cartridge, Mapper, NullMapper};
+use crate::cheat::CheatSet;
 use crate::input::Controller;
 use crate::ppu::Ppu;
 use std::cell::Cell;
@@ -110,6 +111,10 @@ pub struct System {
     /// changed. `None` until the first load or save. A `Cell` so
     /// `save_battery` can take `&self` (docs/debugging/BATTERY_SAVES.md).
     battery_saved_hash: Cell<Option<u64>>,
+    /// Active cheats (docs/debugging/CHEAT_ENGINE.md). ROM patches are
+    /// consulted in `bus_read`; RAM freezes are applied at the start of
+    /// each frame in `run_frame_with_audio`.
+    cheats: CheatSet,
 }
 
 /// A scheduled DMC DMA. The APU's memory reader asks for a byte either
@@ -177,6 +182,7 @@ impl System {
             cartridge: None,
             null_mapper: NullMapper,
             battery_saved_hash: Cell::new(None),
+            cheats: CheatSet::new(),
             instr_cycles: 0,
             dma_cycles: 0,
             dmc_dma: None,
@@ -532,7 +538,15 @@ impl System {
                 0x00
             }
             0x4020..=0xFFFF => match self.cartridge {
-                Some(ref mut cart) => cart.mapper.cpu_read(addr),
+                Some(ref mut cart) => {
+                    let value = cart.mapper.cpu_read(addr);
+                    // Game Genie style ROM patch; `is_active` is one bool.
+                    if self.cheats.is_active() && addr >= 0x8000 {
+                        self.cheats.rom_override(addr, value).unwrap_or(value)
+                    } else {
+                        value
+                    }
+                }
                 None => 0,
             },
             _ => 0,
@@ -610,6 +624,7 @@ impl System {
     ) -> bool {
         let start_frame = self.ppu.frame;
         self.audio_capture = audio_buffer.is_some();
+        self.apply_ram_freezes();
 
         // The PPU frame counter advances inside `tick`, so a frame ends at
         // the end of whichever instruction crosses the boundary.
@@ -3388,6 +3403,64 @@ impl System {
             path.display(),
             ram.len()
         );
+        Ok(true)
+    }
+
+    // ------------------------------------------------------------------
+    // Cheats (docs/debugging/CHEAT_ENGINE.md).
+    // ------------------------------------------------------------------
+
+    pub fn cheats(&self) -> &CheatSet {
+        &self.cheats
+    }
+
+    /// Mutable access to the cheat set. `CheatSet` maintains its own
+    /// active flag, so no refresh is needed after editing through this.
+    pub fn cheats_mut(&mut self) -> &mut CheatSet {
+        &mut self.cheats
+    }
+
+    /// Poke every enabled RAM freeze. Called once at the start of each
+    /// frame; a no-op unless some cheat is enabled.
+    fn apply_ram_freezes(&mut self) {
+        if !self.cheats.is_active() {
+            return;
+        }
+        let freezes: Vec<(u16, u8)> = {
+            let mut v = Vec::new();
+            self.cheats
+                .apply_ram_freezes(|addr, value| v.push((addr, value)));
+            v
+        };
+        for (addr, value) in freezes {
+            self.poke(addr, value);
+        }
+    }
+
+    /// Replace the cheat set with the contents of a `.cht` file.
+    ///
+    /// Returns `Ok(false)` without touching the set when the file does not
+    /// exist. A malformed file is reported as `InvalidData` and leaves the
+    /// current set untouched.
+    pub fn load_cheats(&mut self, path: &Path) -> io::Result<bool> {
+        let text = match std::fs::read_to_string(path) {
+            Ok(text) => text,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(e),
+        };
+        let set = CheatSet::parse(&text)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        log::info!("Loaded {} cheat(s) from {}", set.len(), path.display());
+        self.cheats = set;
+        Ok(true)
+    }
+
+    /// Write the cheat set to `path` in `.cht` format. An empty set is
+    /// written too, so a cleared list does not come back on the next load.
+    /// Returns `Ok(true)` when the file was written.
+    pub fn save_cheats(&self, path: &Path) -> io::Result<bool> {
+        std::fs::write(path, self.cheats.to_string())?;
+        log::info!("Wrote {} cheat(s) to {}", self.cheats.len(), path.display());
         Ok(true)
     }
 

--- a/src/system/tests.rs
+++ b/src/system/tests.rs
@@ -553,3 +553,115 @@ fn dmc_dma_inside_oam_dma_costs_two_extra_cycles() {
         "sample byte fetched during OAM DMA"
     );
 }
+
+// ----------------------------------------------------------------------
+// Cheat engine hooks (docs/debugging/CHEAT_ENGINE.md, issue #31).
+// ----------------------------------------------------------------------
+
+use crate::cheat::Cheat;
+
+const LDA_IMM: u8 = 0xA9;
+
+/// `LDA #$11` at the reset vector; the operand at $8001 is what the cheats
+/// below target.
+fn lda_system() -> System {
+    system_with_rom(|prg| {
+        prg[0] = LDA_IMM;
+        prg[1] = 0x11;
+    })
+}
+
+#[test]
+fn rom_cheat_overrides_cpu_read() {
+    let mut sys = lda_system();
+    sys.cheats_mut().add(Cheat::parse("8001:22").unwrap());
+    assert_eq!(sys.cpu_step(), 2);
+    assert_eq!(sys.reg_a(), 0x22, "operand fetch went through the cheat");
+    assert_eq!(sys.peek(0x8001), 0x11, "peek still shows the real ROM byte");
+}
+
+#[test]
+fn rom_cheat_compare_mismatch_leaves_rom_alone() {
+    let mut sys = lda_system();
+    sys.cheats_mut().add(Cheat::parse("8001?99:22").unwrap());
+    sys.cpu_step();
+    assert_eq!(sys.reg_a(), 0x11);
+
+    let mut sys = lda_system();
+    sys.cheats_mut().add(Cheat::parse("8001?11:22").unwrap());
+    sys.cpu_step();
+    assert_eq!(sys.reg_a(), 0x22, "compare matches the real byte");
+}
+
+#[test]
+fn disabled_rom_cheat_does_nothing() {
+    let mut sys = lda_system();
+    let idx = sys.cheats_mut().add(Cheat::parse("8001:22").unwrap());
+    sys.cheats_mut().toggle(idx);
+    assert!(!sys.cheats().is_active());
+    sys.cpu_step();
+    assert_eq!(sys.reg_a(), 0x11);
+}
+
+#[test]
+fn ram_freeze_reapplied_each_frame() {
+    let mut sys = system();
+    sys.poke(0x0010, 0x05);
+    sys.cheats_mut().add(Cheat::parse("0010:42").unwrap());
+    sys.run_frame();
+    assert_eq!(sys.peek(0x0010), 0x42, "frozen at frame start");
+    // The game overwrites it mid-frame...
+    sys.poke(0x0010, 0x07);
+    assert_eq!(sys.peek(0x0010), 0x07);
+    // ...and the next frame puts it back.
+    sys.run_frame();
+    assert_eq!(sys.peek(0x0010), 0x42);
+
+    // Disabled: the game's value survives.
+    sys.cheats_mut().set_enabled(0, false);
+    sys.poke(0x0010, 0x07);
+    sys.run_frame();
+    assert_eq!(sys.peek(0x0010), 0x07);
+}
+
+#[test]
+fn cheat_file_round_trip_through_system() {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "nes-emu-cheats-{}-{}.cht",
+        std::process::id(),
+        nanos
+    ));
+
+    let mut sys = system();
+    assert!(
+        !sys.load_cheats(&path).unwrap(),
+        "missing file is Ok(false)"
+    );
+    assert!(sys.cheats().is_empty());
+
+    sys.cheats_mut().add(
+        Cheat::parse("SXIOPO")
+            .unwrap()
+            .with_description("Infinite lives"),
+    );
+    sys.cheats_mut().add(Cheat::parse("0010:42").unwrap());
+    sys.cheats_mut().set_enabled(1, false);
+    assert!(sys.save_cheats(&path).unwrap());
+
+    let mut other = system();
+    assert!(other.load_cheats(&path).unwrap());
+    assert_eq!(other.cheats(), sys.cheats());
+    assert!(other.cheats().is_active());
+
+    // A malformed file is InvalidData and leaves the set untouched.
+    std::fs::write(&path, "NOTACODE\t1\tbad\n").unwrap();
+    let err = other.load_cheats(&path).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert_eq!(other.cheats().len(), 2);
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/tests/cheats_smb.rs
+++ b/tests/cheats_smb.rs
@@ -1,0 +1,122 @@
+//! Headless proof that a Game Genie code changes game behaviour
+//! (issue #31, docs/debugging/CHEAT_ENGINE.md).
+//!
+//! SXIOPO is the well-known Super Mario Bros infinite-lives code. It
+//! decodes to $91D9:$AD, turning `DEC $075A` (CE 5A 07, the lives
+//! decrement in the player-death routine) into `LDA $075A`. The test runs
+//! the same input script twice, once without and once with the cheat, and
+//! watches the lives counter at RAM $075A: it must drop in the control run
+//! (proving a death was staged) and must not drop with the cheat.
+//!
+//! ```text
+//! cargo test --release --test cheats_smb -- --ignored --nocapture
+//! ```
+//!
+//! Ignored because `roms/` is not part of the repository.
+
+use nes_emu::cartridge::Cartridge;
+use nes_emu::cheat::Cheat;
+use nes_emu::input::ControllerButton;
+use nes_emu::system::System;
+use std::path::PathBuf;
+
+const LIVES: u16 = 0x075A;
+const PATCH_ADDR: u16 = 0x91D9;
+const START_TAP: usize = 150;
+const RUN_FROM: usize = 300;
+const MAX_FRAMES: usize = 2400;
+
+fn rom_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("roms")
+        .join("mario.nes")
+}
+
+fn load_smb() -> Option<System> {
+    let data = std::fs::read(rom_path()).ok()?;
+    let cart = Cartridge::load_from_bytes(&data).expect("mario.nes should parse");
+    let mut sys = System::new();
+    sys.load_cartridge(cart);
+    Some(sys)
+}
+
+/// Tap Start on the title screen, then hold Right so Mario walks into the
+/// first Goomba. Returns the lives counter after each frame from
+/// `RUN_FROM` onward (SMB initialises $075A during the title screen, so
+/// earlier values are not meaningful), stopping two seconds after the
+/// first change so the post-death state is included.
+fn run(sys: &mut System, label: &str) -> Vec<u8> {
+    let mut trace = Vec::with_capacity(MAX_FRAMES);
+    let mut changed_at = None;
+    for f in 0..MAX_FRAMES {
+        if f == START_TAP {
+            sys.controller1.press(ControllerButton::START);
+        }
+        if f == START_TAP + 8 {
+            sys.controller1.release(ControllerButton::START);
+        }
+        if f == RUN_FROM {
+            sys.controller1.press(ControllerButton::RIGHT);
+        }
+        sys.run_frame();
+        if f < RUN_FROM {
+            continue;
+        }
+        let lives = sys.peek(LIVES);
+        if let Some(prev) = trace.last().copied() {
+            if lives != prev {
+                println!("{label}: frame {f}: $075A {prev:02X} -> {lives:02X}");
+                changed_at.get_or_insert(f);
+            }
+        }
+        trace.push(lives);
+        if changed_at.is_some_and(|c| f > c + 120) {
+            break;
+        }
+    }
+    println!(
+        "{label}: ran {} frames, $075A at frame {RUN_FROM} {:02X}, final {:02X}",
+        trace.len() + RUN_FROM,
+        trace[0],
+        trace[trace.len() - 1]
+    );
+    trace
+}
+
+#[test]
+#[ignore = "needs roms/mario.nes (not in the repository)"]
+fn sxiopo_keeps_smb_lives_from_decreasing() {
+    let Some(mut control) = load_smb() else {
+        println!("roms/mario.nes not found; skipping");
+        return;
+    };
+    // The bytes the code patches: the opcode of DEC $075A.
+    assert_eq!(control.peek(PATCH_ADDR), 0xCE, "expected DEC abs at $91D9");
+    assert_eq!(control.peek(PATCH_ADDR + 1), 0x5A);
+    assert_eq!(control.peek(PATCH_ADDR + 2), 0x07);
+
+    let control_trace = run(&mut control, "control");
+
+    let mut cheated = load_smb().unwrap();
+    cheated.cheats_mut().add(Cheat::parse("SXIOPO").unwrap());
+    assert_eq!(cheated.cheats().rom_override(PATCH_ADDR, 0xCE), Some(0xAD));
+    let cheat_trace = run(&mut cheated, "sxiopo");
+
+    // Lives are stored minus one (2 = three lives shown). Both runs start
+    // from the same power-on state, so the counter must only ever drop in
+    // the control run.
+    let control_first = control_trace[0];
+    let control_min = *control_trace.iter().min().unwrap();
+    let cheat_first = cheat_trace[0];
+    let cheat_min = *cheat_trace.iter().min().unwrap();
+    println!("control: first {control_first:02X} min {control_min:02X}; sxiopo: first {cheat_first:02X} min {cheat_min:02X}");
+    assert_eq!(cheat_first, control_first);
+    assert!(
+        control_min < control_first,
+        "control run never lost a life ($075A stayed {control_first:02X}); death not staged within {MAX_FRAMES} frames"
+    );
+    assert!(
+        cheat_min >= cheat_first,
+        "lives dropped with SXIOPO active: {cheat_min:02X} < {cheat_first:02X}"
+    );
+}


### PR DESCRIPTION
Implements the cheat engine in the library (Phase 2 of docs/plans/TOOLS_AND_CHEATS.md). No new crate dependencies; no UI changes.

## What is in the change

- `src/cheat.rs`: `Cheat { code, description, enabled, kind }`, `CheatKind::{Rom { addr, value, compare }, RamFreeze { addr, value }}`, `CheatSet` (add/remove/toggle/iter, `rom_override`, `apply_ram_freezes`, `Display`/`FromStr` for the `.cht` format). Game Genie 6 and 8 letter decoding per the nesdev bit layout; raw `AAAA:VV` (RAM freeze below `$8000`, ROM patch otherwise) and `AAAA?CC:VV` (ROM patch with compare). Case-insensitive, whitespace and dashes ignored.
- `System`: a `cheats: CheatSet` field with `cheats()` / `cheats_mut()`; the `bus_read` cartridge arm consults `rom_override` only when `cheats.is_active() && addr >= 0x8000` (one bool load when no cheat is enabled); RAM freezes poked once at the start of `run_frame_with_audio`; `load_cheats` / `save_cheats` in the battery-save style (missing file is `Ok(false)`, malformed file is `InvalidData` and leaves the set untouched).
- Docs: `docs/debugging/CHEAT_ENGINE.md` (formats, decoding with the SXIOPO worked example, hook points, `.cht` format, verification, debugging notes) and a line in `docs/README.md`.

`read_byte`, `tick` and `cpu_step` are untouched; the only change near them is the one match arm in `bus_read`.

## What the tests verify

`src/cheat.rs` (12 tests):
- `SXIOPO` decodes to `$91D9:$AD`, and is the same after `sxi-opo` / `sx io po` normalisation.
- `GZUXNGEI` decodes to `$AC3F`, value `$24`, compare `$D0`; its address equals that of `GZUXNG` (address bits never use letters 7-8); the third letter's bit 3 flags the code length for both examples.
- 500 random address/value/compare triples encode (inverse bit layout) and decode back to themselves, for both 6 and 8 letter forms; `encode` also reproduces `SXIOPO` and `GZUXNGEI`.
- Bad letters, lengths and malformed raw codes are rejected with the right `CheatError`.
- `rom_override`: compare mismatch returns `None`, other address returns `None`, disabled or removed cheat deactivates the set.
- `apply_ram_freezes` skips disabled cheats and ROM cheats.
- `.cht` round trip preserves order, enabled flags and descriptions; comments, CRLF and missing fields are tolerated; a bad line reports its line number.

`src/system/tests.rs` (5 tests, through the real CPU):
- `LDA #$11` at the reset vector with a cheat on `$8001` loads `$22` after one `cpu_step`, while `peek(0x8001)` still shows `$11`.
- A compare mismatch (`8001?99:22`) leaves A at `$11`; a matching compare (`8001?11:22`) loads `$22`.
- A toggled-off cheat leaves A at `$11` and `is_active()` false.
- A RAM freeze (`0010:42`) is restored by the next `run_frame` after the "game" pokes `$07` over it, and stops being restored once disabled.
- `save_cheats` / `load_cheats` round trip through a temp file; missing file is `Ok(false)`; a malformed file is `InvalidData` and does not touch the loaded set.

Quality gates: `cargo build`, `cargo test` (129 lib tests, battery 4, blargg 75 passing / 1 ignored as before, nestest 7), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean. nestest and blargg are unchanged with the hook in place.

## Headless Super Mario Bros check

`tests/cheats_smb.rs` (ignored; needs `roms/mario.nes`, which is gitignored):

```
cargo test --release --test cheats_smb -- --ignored --nocapture
```

Same input script twice (Start tapped at frame 150, Right held from frame 300 so Mario walks into the first Goomba), watching the lives counter at `$075A`:

```
control: frame 720: $075A 02 -> 01
control: ran 842 frames, $075A at frame 300 02, final 01
sxiopo: ran 2400 frames, $075A at frame 300 02, final 02
```

Without the cheat the counter drops from 02 to 01 at frame 720 when the death sequence finishes. With `SXIOPO` active, under identical input, `$075A` stayed at 02 for all 2400 frames. The test first asserts the real bytes at `$91D9` are `CE 5A 07` (`DEC $075A`), which the code patches to `AD` (`LDA $075A`), and that `rom_override(0x91D9, 0xCE) == Some(0xAD)`.

Closes #31
