### PR TITLE
feat(input): wire the second controller port and player 2 keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Or use the provided test scripts:
 - **X**: B button  
 - **Enter**: Start
 - **Right Shift**: Select
+- Player 2: **I** / **J** / **K** / **L**: D-pad (Up / Left / Down / Right), **Apostrophe**: A, **Semicolon**: B, **Period**: Start, **Comma**: Select
 - **Backquote**: Open the command palette (type to filter, Enter runs, Escape closes)
 - **F1**: Help page with every key and command
 - **P** / **N**: Pause or resume / frame advance

--- a/docs/debugging/UI_FRAMEWORK.md
+++ b/docs/debugging/UI_FRAMEWORK.md
@@ -352,6 +352,17 @@ two page screenshots; the file afterwards reads `075A:02<TAB>1<TAB>lives`.
 | Right Shift | Select |
 | Return | Start |
 | Arrows | D-pad |
+| Apostrophe / Semicolon | Player 2 A / B |
+| Period / Comma | Player 2 Start / Select |
+| I / J / K / L | Player 2 D-pad (Up / Left / Down / Right) |
+
+Player 2 keys (issue #42) collide with no hotkey in `main::key_down`
+(Escape, F1, R, P, N, M, Plus, Minus, F5-F8) nor with the backquote.
+The page-local keys (Q, A/E/D on Cheats, 1-5 view toggles) and palette
+typing only run in `Tool` and `Palette` mode, where the UI consumes the
+press before the controller map is consulted, so typing `l` or `;` in
+the palette does not move player 2; releases still reach both
+controllers, by design.
 
 Inside the palette: type to filter, Backspace, Up/Down, Enter, Escape.
 Inside Help: Up/Down/PageUp/PageDown/Home scroll; Escape, Q or Return

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,17 +70,46 @@ impl AudioCallback for ApuAudioCallback {
     }
 }
 
-fn map_keycode_to_button(key: Keycode) -> Option<ControllerButton> {
+/// Which controller port a key belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Player {
+    One,
+    Two,
+}
+
+/// Default key map for both controllers (README "Controls"). Player 2 uses
+/// I/J/K/L for the D-pad, apostrophe/semicolon for A/B and period/comma for
+/// Start/Select; none of these are hotkeys in `key_down`, and page-local
+/// keys and palette typing only run while the UI owns the keyboard.
+fn map_keycode_to_button(key: Keycode) -> Option<(Player, ControllerButton)> {
+    use ControllerButton as B;
+    use Player::{One, Two};
     match key {
-        Keycode::Z => Some(ControllerButton::A),
-        Keycode::X => Some(ControllerButton::B),
-        Keycode::RShift => Some(ControllerButton::SELECT),
-        Keycode::Return => Some(ControllerButton::START),
-        Keycode::Up => Some(ControllerButton::UP),
-        Keycode::Down => Some(ControllerButton::DOWN),
-        Keycode::Left => Some(ControllerButton::LEFT),
-        Keycode::Right => Some(ControllerButton::RIGHT),
+        Keycode::Z => Some((One, B::A)),
+        Keycode::X => Some((One, B::B)),
+        Keycode::RShift => Some((One, B::SELECT)),
+        Keycode::Return => Some((One, B::START)),
+        Keycode::Up => Some((One, B::UP)),
+        Keycode::Down => Some((One, B::DOWN)),
+        Keycode::Left => Some((One, B::LEFT)),
+        Keycode::Right => Some((One, B::RIGHT)),
+        Keycode::Quote => Some((Two, B::A)),
+        Keycode::Semicolon => Some((Two, B::B)),
+        Keycode::Comma => Some((Two, B::SELECT)),
+        Keycode::Period => Some((Two, B::START)),
+        Keycode::I => Some((Two, B::UP)),
+        Keycode::K => Some((Two, B::DOWN)),
+        Keycode::J => Some((Two, B::LEFT)),
+        Keycode::L => Some((Two, B::RIGHT)),
         _ => None,
+    }
+}
+
+/// The controller a mapped key drives.
+fn controller_for(app: &mut App, player: Player) -> &mut nes_emu::input::Controller {
+    match player {
+        Player::One => &mut app.system.controller1,
+        Player::Two => &mut app.system.controller2,
     }
 }
 
@@ -206,8 +235,8 @@ fn key_down(key: Keycode, app: &mut App, ui: &mut Ui) {
         Keycode::F8 => app.load_state(),
         _ => {}
     }
-    if let Some(button) = map_keycode_to_button(key) {
-        app.system.controller1.press(button);
+    if let Some((player, button)) = map_keycode_to_button(key) {
+        controller_for(app, player).press(button);
     }
 }
 
@@ -230,8 +259,8 @@ fn draw_message(canvas: &mut WindowCanvas, font_scale: u32, text: &str) -> Resul
 /// Releases reach the controller in every UI mode so a button held when
 /// the palette opened does not stick.
 fn key_up(key: Keycode, app: &mut App) {
-    if let Some(button) = map_keycode_to_button(key) {
-        app.system.controller1.release(button);
+    if let Some((player, button)) = map_keycode_to_button(key) {
+        controller_for(app, player).release(button);
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -539,8 +539,9 @@ impl System {
                 value
             }
             0x4017 => {
-                // Controller 2 not connected, return 0
-                0x00
+                let value = self.controller2.read();
+                log::trace!("CPU reading $4017: value={:02X}", value);
+                value
             }
             0x4020..=0xFFFF => match self.cartridge {
                 Some(ref mut cart) => {
@@ -591,8 +592,9 @@ impl System {
             }
             0x4016 => {
                 log::trace!("CPU writing $4016: value={:02X}", value);
+                // One strobe line feeds both ports.
                 self.controller1.write(value);
-                // Controller 2 strobe is handled but we don't have a second controller
+                self.controller2.write(value);
             }
             0x4017 => self.apu.write_register(addr, value),
             0x4020..=0xFFFF => {

--- a/src/system/tests.rs
+++ b/src/system/tests.rs
@@ -480,6 +480,67 @@ fn dmc_dma_halting_a_4016_read_clocks_the_controller_twice() {
 }
 
 #[test]
+fn dmc_dma_halting_a_4017_read_clocks_controller_2_twice() {
+    // Same as the $4016 case for the second port: LDA $4017 halted by a
+    // load DMA sees the second shifted bit of controller 2.
+    let mut system = system_with_rom(|prg| {
+        prg[0] = 0xAD;
+        prg[1] = 0x17;
+        prg[2] = 0x40;
+    });
+    system.controller2.press(ControllerButton::B);
+    system.write_byte(0x4016, 0x01);
+    system.write_byte(0x4016, 0x00);
+    program_dmc(&mut system, 0x00);
+    if System::is_get_cycle(system.total_cycles + 1 + 3) {
+        system.tick();
+    }
+    system.write_byte(0x4015, 0x10);
+
+    let cycles = system.cpu_step();
+    assert_eq!(cycles, 4 + 3, "load DMA stalls the $4017 read by 3 cycles");
+    assert_eq!(system.cpu_a & 1, 1, "CPU read the second shifted bit (B)");
+    assert_eq!(
+        system.read_byte(0x4017) & 1,
+        0,
+        "the next read is the third bit (Select)"
+    );
+}
+
+#[test]
+fn both_controller_ports_shift_out_their_own_buttons_after_a_strobe() {
+    // Disjoint button sets so every bit position tells the ports apart.
+    let mut system = system();
+    for b in [
+        ControllerButton::A,
+        ControllerButton::SELECT,
+        ControllerButton::UP,
+        ControllerButton::LEFT,
+    ] {
+        system.controller1.press(b);
+    }
+    for b in [
+        ControllerButton::B,
+        ControllerButton::START,
+        ControllerButton::DOWN,
+        ControllerButton::RIGHT,
+    ] {
+        system.controller2.press(b);
+    }
+    // One $4016 write strobes both ports.
+    system.write_byte(0x4016, 0x01);
+    system.write_byte(0x4016, 0x00);
+    let port1: Vec<u8> = (0..8).map(|_| system.read_byte(0x4016) & 1).collect();
+    let port2: Vec<u8> = (0..8).map(|_| system.read_byte(0x4017) & 1).collect();
+    // Order: A, B, Select, Start, Up, Down, Left, Right.
+    assert_eq!(port1, [1, 0, 1, 0, 1, 0, 1, 0], "controller 1 sequence");
+    assert_eq!(port2, [0, 1, 0, 1, 0, 1, 0, 1], "controller 2 sequence");
+    // Both ports are exhausted independently: open bus reads as 1.
+    assert_eq!(system.read_byte(0x4016) & 1, 1);
+    assert_eq!(system.read_byte(0x4017) & 1, 1);
+}
+
+#[test]
 fn reload_dma_stalls_four_cycles_and_can_halt_on_a_padded_cycle() {
     // A stream of NOPs: two cycles each, the second one padded (a dummy
     // read of the next opcode on hardware). 17-byte sample so several

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -44,6 +44,9 @@ pub const KEY_BINDINGS: &[(&str, &str)] = &[
     ("Right Shift", "Select"),
     ("Return", "Start"),
     ("Arrows", "D-pad"),
+    ("Quote / ;", "P2 A / B"),
+    ("Period / ,", "P2 Start / Select"),
+    ("I/J/K/L", "P2 D-pad"),
     ("In pages", "Left/Right views, 1-5 toggles"),
 ];
 


### PR DESCRIPTION
## Summary

- `$4017` reads return controller 2 bit 0 (upper bits stay 0); a `$4016` write strobes both ports.
- The DMC DMA halted-read repeat (`repeat_halted_read`) already treated `$4016` and `$4017` alike, so no DMA change was needed; a new test shows a halted `LDA $4017` clocks controller 2 twice, mirroring the port 1 test.
- Player 2 default keys: I/J/K/L D-pad, apostrophe A, semicolon B, period Start, comma Select. `map_keycode_to_button` now returns the player with the button; `key_down`/`key_up` route to the right controller. No collision with the hotkeys (Escape, F1, R, P, N, M, Plus, Minus, F5-F8, backquote); page-local keys and palette typing only run while the UI owns the keyboard.
- Save states already snapshot both controllers in the `INPT` section (verified; no change).
- Help page key table, README controls list and `docs/debugging/UI_FRAMEWORK.md` key table updated.

## Tests

- `system::tests::both_controller_ports_shift_out_their_own_buttons_after_a_strobe`: disjoint button sets on both controllers, strobe via `$4016`, eight reads from each port through the bus.
- `system::tests::dmc_dma_halting_a_4017_read_clocks_controller_2_twice`.
- `cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all pass; nestest and blargg (including `dmc_dma_4016_read`) green.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
