### PR TITLE
feat(cartridge): add mappers 7, 9, 10, 11, 66 and 69

### DIFF
--- a/docs/debugging/MAPPER_TRAIT_REFACTOR.md
+++ b/docs/debugging/MAPPER_TRAIT_REFACTOR.md
@@ -53,6 +53,10 @@ pub trait Mapper: Send {
     fn irq_pending(&self) -> bool { false }
     fn clear_irq(&mut self) {}
     fn clock_scanline(&mut self) {}
+    fn ppu_a12_rise(&mut self) {}          // MMC3 (issue 3)
+    fn ppu_fetch(&mut self, addr: u16) {}  // MMC2/MMC4 latches (issue 43)
+    fn cpu_clock(&mut self) {}             // FME-7 IRQ counter (issue 43)
+    // plus cpu_peek/ppu_peek, prg_ram/prg_ram_mut, save_state/load_state
 }
 ```
 
@@ -117,6 +121,12 @@ using the mirroring the mapper reports at that moment.
 | `mapper5.rs` | MMC5 | Wired for the first time. PRG/CHR modes, multiplier, ExRAM, register file. ExRAM nametables, fill mode and the vertical split are recorded but not rendered (the PPU has no per-table nametable hook); `mirroring()` approximates `$5105`. |
 | `mapper65.rs` | Irem H3001 | Moved out of `mod.rs`. CHR registers corrected from `$9000-$9007` to `$B000-$B007` (nesdev); the old offset never mattered because CHR never reached the PPU. |
 | `mapper227.rs` | Address-latch multicart (1200-in-1) | Added for issue 25, see below. |
+| `mapper7.rs` | AxROM | 32 KB PRG bank, single-screen mirroring from the register, CHR RAM. Issue 43. |
+| `mapper9.rs` | MMC2 (PNROM) | 8 KB PRG bank with the last three fixed, four 4 KB CHR registers picked by the two tile-$FD/$FE latches, which the PPU flips through `ppu_fetch`. Holds the `Mmc2Core` shared with MMC4. Issue 43. |
+| `mapper10.rs` | MMC4 (FxROM) | `Mmc2Core` with 16 KB PRG banking and the whole-row latch 0. Issue 43. |
+| `mapper11.rs` | Color Dreams | 32 KB PRG from bits 0-1, 8 KB CHR from bits 4-7. Issue 43. |
+| `mapper66.rs` | GxROM | 32 KB PRG from bits 4-5, 8 KB CHR from bits 0-1. Issue 43. |
+| `mapper69.rs` | Sunsoft FME-7 | Command/parameter registers, 1 KB CHR banks, 8 KB PRG banks with the `$6000` RAM/ROM slot, four mirroring modes, 16-bit IRQ counter clocked per CPU cycle through `cpu_clock`. Issue 43. |
 
 ### Mapper 227 (issue 25)
 
@@ -165,6 +175,119 @@ does nothing on this menu; it is not a navigation key there. The
 compatibility sweep's fixed script (Start at 150) therefore lands in
 Bomberman stage 1.
 
+### Mappers 7, 9, 10, 11, 66, 69 (issue 43)
+
+Six more boards for library coverage. None of the ROMs in `roms/` needed
+them except `SuperMarioBros.nes`, which turned out to be the GxROM (mapper
+66, 64 KB PRG, 16 KB CHR) Super Mario Bros / Duck Hunt cart and had been
+running on the NROM fallback; see the verification notes below. All six
+follow the `mapper2.rs`/`mapper4.rs` shape: `cpu_read` delegates to
+`cpu_peek`, `ppu_peek` mirrors `ppu_read` without side effects, PRG RAM is
+an 8 KB array exposed through `prg_ram`/`prg_ram_mut` even on boards that
+have none (UxROM already does this), and `save_state` writes the registers
+first, then PRG RAM, then `Chr::save_state`.
+
+Two hooks were added to the trait so that the mappers, not the PPU or
+`System`, own the timing-sensitive state:
+
+- `ppu_fetch(addr)`: `Ppu::read_vram` calls it right after `mapper.ppu_read`
+  for every pattern-table access, so background fetches, sprite fetches and
+  `$2007` reads all report. Ordering is the point: the byte at the trigger
+  address comes from the bank selected before the flip, the next fetch from
+  the new one. `ppu_peek` never calls it. Existing mappers use the default
+  no-op, so the fingerprints of every other ROM are unchanged.
+- `cpu_clock()`: `System::tick` calls it once per CPU cycle, after the APU
+  step and before `sample_irq_input`, so a counter wrap in this cycle is
+  visible to the IRQ sample of the same cycle. `tick` is the only place
+  `total_cycles` advances (DMA stalls go through it too), so the FME-7 count
+  is exact.
+
+#### Mapper 7 (AxROM)
+
+One register anywhere in `$8000-$FFFF`: bits 0-2 pick the 32 KB PRG bank,
+bit 4 picks the single nametable page (0 = `SingleScreenLower`, 1 =
+`SingleScreenUpper`). CHR is 8 KB RAM, unbanked. The header mirroring is
+ignored because the register owns it; power-on is bank 0, lower page.
+
+#### Mappers 9 (MMC2) and 10 (MMC4)
+
+`mapper9.rs` holds `Mmc2Core` with a `Kind` switch; `Mapper9` and
+`Mapper10` are newtypes that forward every trait method through the
+`forward_mmc2_core!` macro. Registers (nesdev "MMC2", "MMC4"):
+
+```text
+$A000-$AFFF  PRG bank (bits 0-3)
+             MMC2: 8 KB at $8000-$9FFF, $A000-$FFFF = last three 8 KB banks
+             MMC4: 16 KB at $8000-$BFFF, $C000-$FFFF = last 16 KB bank
+$B000/$C000  4 KB CHR bank for $0000-$0FFF while latch 0 = $FD / $FE
+$D000/$E000  4 KB CHR bank for $1000-$1FFF while latch 1 = $FD / $FE
+$F000-$FFFF  mirroring bit 0: 0 vertical, 1 horizontal
+```
+
+The latches flip on PPU reads (reported through `ppu_fetch`) of the high
+plane of tiles `$FD` and `$FE`:
+
+| Trigger | MMC2 | MMC4 |
+|---------|------|------|
+| latch 0 = `$FD` | `$0FD8` only | `$0FD8-$0FDF` |
+| latch 0 = `$FE` | `$0FE8` only | `$0FE8-$0FEF` |
+| latch 1 = `$FD` | `$1FD8-$1FDF` | `$1FD8-$1FDF` |
+| latch 1 = `$FE` | `$1FE8-$1FEF` | `$1FE8-$1FEF` |
+
+The decode is an explicit match on the full address, not a mask: an early
+version masked off bit 13 and a unit test caught `$2FE8` aliasing onto
+`$0FE8`. Power-on latches are `$FE` (unspecified on hardware; the common
+emulator choice). Both boards get 8 KB PRG RAM at `$6000` (MMC4 boards
+have it, battery backed on Fire Emblem; MMC2 boards do not, but the array
+is harmless).
+
+#### Mapper 11 (Color Dreams)
+
+One register: bits 0-1 the 32 KB PRG bank, bits 4-7 the 8 KB CHR bank, bits
+2-3 are the lockout-defeat lines and ignored. Mirroring from the header.
+
+#### Mapper 66 (GxROM)
+
+One register: bits 4-5 the 32 KB PRG bank, bits 0-1 the 8 KB CHR bank.
+Mirroring from the header. Bus conflicts are not modelled on either 11 or
+66.
+
+#### Mapper 69 (Sunsoft FME-7)
+
+`$8000-$9FFF` selects a command (bits 0-3), `$A000-$BFFF` writes its
+parameter; `$C000-$FFFF` is the 5B audio chip and ignored.
+
+```text
+$0-$7  1 KB CHR bank for $0000 + n * $400
+$8     $6000-$7FFF slot: ERbB BBBB. R = 1 selects PRG RAM, readable and
+       writable only while E = 1 (otherwise open bus, returned as 0);
+       R = 0 maps 8 KB PRG ROM bank bBBBBB there
+$9-$B  8 KB PRG ROM bank (bits 0-5) at $8000, $A000, $C000;
+       $E000-$FFFF fixed to the last bank
+$C     mirroring bits 0-1: 0 horizontal, 1 vertical, 2 single lower,
+       3 single upper (note 0 is horizontal, the opposite of MMC1/MMC3)
+$D     IRQ control: bit 0 IRQ output enable, bit 7 counter enable;
+       every write acknowledges the IRQ
+$E/$F  IRQ counter low / high byte
+```
+
+The 16-bit counter decrements once per `cpu_clock` while bit 7 is set and
+raises the IRQ on the `$0000` to `$FFFF` wrap when bit 0 is set. It keeps
+counting after the wrap and the line stays asserted until a command `$D`
+write (or `clear_irq`).
+
+#### Tests
+
+Each file has unit tests on `tagged_rom` images: power-on layout, every
+bank field including the bits that must not leak into it, wrap to the image
+size, mirroring, the `$6000` slot modes and open bus (69), the IRQ counter
+(exact cycle count, high byte, counter-enable and IRQ-enable independently,
+acknowledge), and a save-state round trip that switches banks, saves,
+switches again, loads and checks the reads match. The MMC2/MMC4 tests drive
+`ppu_fetch` directly for every trigger row and a set of non-triggers, and
+`src/ppu/mod.rs` has `pattern_reads_report_the_fetch_to_the_mapper_after_the_byte`,
+which proves the wiring through `$2007` and `fetch_pattern_high`.
+
 ### Behaviour changes beyond CHR routing
 
 - Out-of-range PRG bank reads wrap to the ROM size instead of returning 0.
@@ -192,6 +315,16 @@ Bomberman stage 1.
 - Frame dumps: a scratch harness ran each ROM for several hundred frames
   against a build of `main` and this branch and diffed the RGB buffers (table
   above).
+- Issue 43: `cargo test --release --test game_frames -- --ignored --nocapture`
+  before and after. Ten of the eleven ROMs are hash-identical at every
+  checkpoint, which is the expected result of a no-op default hook. The one
+  change is `SuperMarioBros.nes`: its header says mapper 66, so it moved
+  from the NROM fallback (last 32 KB of a 64 KB image) to `Mapper66` and now
+  boots to the real title screen. Frame dumps at 240 (appendix harness,
+  built once against a `git archive main` extraction and once against the
+  branch): main showed the title logo half drawn with garbage tiles from
+  the wrong CHR bank where the text and ground should be; the branch shows
+  the standard SMB title, 1985 Nintendo line, player menu and ground tiles.
 
 ### Human visual pass still needed
 
@@ -206,7 +339,14 @@ black lower region until #3 lands, Zelda unchanged from before.
 2. Implement `Mapper`. Use `prg_read(&self.prg_rom, offset)` and
    `self.chr.read(offset)` so bank offsets wrap safely. Return the live
    mirroring from `mirroring()`; override `irq_pending`, `clear_irq` and
-   `clock_scanline` only if the board has an IRQ.
+   one of `clock_scanline` (MMC5), `ppu_a12_rise` (MMC3) or `cpu_clock`
+   (FME-7) only if the board has an IRQ. Override `ppu_fetch` only if the
+   board watches the PPU address bus (MMC2/MMC4 latches); never flip state
+   from `ppu_read` or `ppu_peek`.
+   Implement `cpu_peek`, `ppu_peek`, `prg_ram`/`prg_ram_mut` and
+   `save_state`/`load_state` (order documented in a comment above
+   `save_state`, ending with PRG RAM then `Chr::save_state`); add the row
+   to the `MAPR` table in docs/debugging/SAVE_STATES.md.
 3. Add `pub mod mapperN;` and a match arm in `Cartridge::build_mapper`.
 4. Add unit tests with `mapper::test_util::tagged_rom` so bank arithmetic is
    checked without a ROM image.

--- a/docs/debugging/SAVE_STATES.md
+++ b/docs/debugging/SAVE_STATES.md
@@ -139,6 +139,11 @@ blob length must match the loaded cartridge.
 | 5 MMC5 | exram 1 KB, exram_mode, prg_mode, prg_banks x 5, prg_ram_protect x 2, chr_mode, chr_banks 12 x u16, upper_chr_bank_bits, nametable_mapping x 4, fill mode, vertical split registers, IRQ registers and counter, ppu_is_rendering, multiplier operands |
 | 65 H3001 | mirroring u8, prg_banks x 3, chr_banks x 8 |
 | 227 | latch u16 |
+| 7 AxROM | prg_bank u8, upper_nametable bool |
+| 9 MMC2 / 10 MMC4 | prg_bank u8, chr_fd x 2, chr_fe x 2, latch_fe x 2 (bool), mirroring u8 |
+| 11 Color Dreams | mirroring u8, prg_bank u8, chr_bank u8 |
+| 66 GxROM | mirroring u8, prg_bank u8, chr_bank u8 |
+| 69 FME-7 | command u8, chr_banks x 8, prg_6000 u8, prg_banks x 3, mirroring u8, irq_enabled bool, irq_counter_enabled bool, irq_counter u16, irq_pending bool |
 
 `Mapper` gained `save_state(&self, &mut Writer)` and
 `load_state(&mut self, &mut Reader) -> Result<(), StateError>` with

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -56,6 +56,19 @@ pub trait Mapper: Send {
     /// its IRQ counter here. No-op for everything else.
     fn ppu_a12_rise(&mut self) {}
 
+    /// A completed PPU read of pattern-table address `addr` ($0000-$1FFF),
+    /// called by the PPU after `ppu_read` returned the byte, for every
+    /// pattern fetch (background, sprite and $2007). MMC2/MMC4 flip their
+    /// CHR latches here when the fetch was tile $FD or $FE, so the byte
+    /// fetched comes from the old bank and the next one from the new. No-op
+    /// for everything else; `ppu_peek` must never call it.
+    fn ppu_fetch(&mut self, _addr: u16) {}
+
+    /// One CPU cycle has elapsed. Called by `System::tick` once per cycle,
+    /// before the CPU samples its IRQ input. FME-7 decrements its 16-bit IRQ
+    /// counter here. No-op for everything else.
+    fn cpu_clock(&mut self) {}
+
     /// Borrow the board's PRG RAM ($6000-$7FFF) for battery persistence.
     /// `None` for boards without PRG RAM. Returns the raw array even when
     /// the board has gated it off the bus (MMC3 $A001), since that gate

--- a/src/cartridge/mapper10.rs
+++ b/src/cartridge/mapper10.rs
@@ -1,0 +1,153 @@
+//! Mapper 10 (MMC4 / FxROM).
+//!
+//! Used by Fire Emblem, Fire Emblem Gaiden, Famicom Wars.
+//!
+//! Same registers and CHR latches as the MMC2 (see `mapper9.rs`) with two
+//! differences:
+//!   $A000-$AFFF  PRG bank (bits 0-3): 16 KB at $8000-$BFFF; $C000-$FFFF is
+//!                fixed to the last 16 KB bank
+//!   latch 0      flips on any of $0FD8-$0FDF / $0FE8-$0FEF, not just the
+//!                first row, matching latch 1
+//! 8 KB PRG RAM at $6000-$7FFF (battery backed on the Fire Emblem boards).
+
+use super::mapper::Mapper;
+use super::mapper9::{forward_mmc2_core, Kind, Mmc2Core};
+use super::Mirroring;
+
+pub struct Mapper10(Mmc2Core);
+
+impl Mapper10 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mapper10(Mmc2Core::new(Kind::Mmc4, prg_rom, chr_rom, mirroring))
+    }
+}
+
+forward_mmc2_core!(Mapper10);
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    /// 8 x 16 KB PRG, 32 x 4 KB CHR (tagged 0x80 | bank).
+    fn mmc4() -> Mapper10 {
+        let chr: Vec<u8> = tagged_rom(32, 0x1000).iter().map(|b| b | 0x80).collect();
+        Mapper10::new(tagged_rom(8, 0x4000), chr, Mirroring::Vertical)
+    }
+
+    fn set_chr(m: &mut Mapper10, fd0: u8, fe0: u8, fd1: u8, fe1: u8) {
+        m.cpu_write(0xB000, fd0);
+        m.cpu_write(0xC000, fe0);
+        m.cpu_write(0xD000, fd1);
+        m.cpu_write(0xE000, fe1);
+    }
+
+    #[test]
+    fn prg_16k_switchable_with_last_fixed() {
+        let mut m = mmc4();
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xBFFF), 0);
+        assert_eq!(m.cpu_read(0xC000), 7);
+        assert_eq!(m.cpu_read(0xFFFF), 7);
+        m.cpu_write(0xA000, 5);
+        assert_eq!(m.cpu_read(0x8000), 5);
+        assert_eq!(m.cpu_read(0xBFFF), 5);
+        assert_eq!(m.cpu_read(0xC000), 7);
+        m.cpu_write(0xAFFF, 0xF3);
+        assert_eq!(m.cpu_read(0x8000), 3);
+        m.cpu_write(0x9000, 1);
+        assert_eq!(m.cpu_read(0x8000), 3, "sub-$A000 writes are not registers");
+    }
+
+    #[test]
+    fn prg_bank_wraps_to_rom_size() {
+        let mut m = Mapper10::new(tagged_rom(2, 0x4000), vec![], Mirroring::Vertical);
+        m.cpu_write(0xA000, 3);
+        assert_eq!(m.cpu_read(0x8000), 1);
+        assert_eq!(m.cpu_read(0xC000), 1);
+    }
+
+    #[test]
+    fn latch_0_decodes_all_rows_on_mmc4() {
+        let mut m = mmc4();
+        set_chr(&mut m, 1, 2, 3, 4);
+        for row in 0..8u16 {
+            m.ppu_fetch(0x0FD8 + row);
+            assert_eq!(m.ppu_read(0x0000), 0x81, "row {row}");
+            m.ppu_fetch(0x0FE8 + row);
+            assert_eq!(m.ppu_read(0x0000), 0x82, "row {row}");
+        }
+    }
+
+    #[test]
+    fn latch_1_decodes_all_rows() {
+        let mut m = mmc4();
+        set_chr(&mut m, 1, 2, 3, 4);
+        for row in 0..8u16 {
+            m.ppu_fetch(0x1FD8 + row);
+            assert_eq!(m.ppu_read(0x1000), 0x83, "row {row}");
+            m.ppu_fetch(0x1FE8 + row);
+            assert_eq!(m.ppu_read(0x1000), 0x84, "row {row}");
+        }
+    }
+
+    #[test]
+    fn latches_are_independent_and_other_fetches_do_not_flip() {
+        let mut m = mmc4();
+        set_chr(&mut m, 1, 2, 3, 4);
+        m.ppu_fetch(0x0FDA);
+        assert_eq!(m.ppu_read(0x0000), 0x81);
+        assert_eq!(m.ppu_read(0x1000), 0x84);
+        for addr in [0x0FE0, 0x0FE7, 0x0FC8, 0x0FF8, 0x1FF8, 0x2FE8] {
+            m.ppu_fetch(addr);
+        }
+        assert_eq!(m.ppu_read(0x0000), 0x81);
+        assert_eq!(m.ppu_read(0x1000), 0x84);
+        assert_eq!(m.ppu_peek(0x0000), 0x81);
+    }
+
+    #[test]
+    fn mirroring_register_and_prg_ram() {
+        let mut m = mmc4();
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        m.cpu_write(0xF000, 1);
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+        m.cpu_write(0x6000, 0x42);
+        assert_eq!(m.cpu_read(0x6000), 0x42);
+        assert_eq!(m.prg_ram().unwrap()[0], 0x42);
+        m.prg_ram_mut().unwrap()[1] = 0x24;
+        assert_eq!(m.cpu_peek(0x6001), 0x24);
+    }
+
+    #[test]
+    fn save_state_round_trips_banks_and_latches() {
+        use crate::state::{Reader, Writer};
+        let mut m = mmc4();
+        m.cpu_write(0xA000, 6);
+        set_chr(&mut m, 1, 2, 3, 4);
+        m.ppu_fetch(0x1FDF); // latch 1 = FD, latch 0 stays FE
+        m.cpu_write(0x7000, 0xAB);
+        let mut w = Writer::new();
+        m.save_state(&mut w);
+        let bytes = w.into_bytes();
+        let snapshot =
+            |m: &mut Mapper10| (m.cpu_read(0x8000), m.ppu_read(0x0000), m.ppu_read(0x1000));
+        let before = snapshot(&mut m);
+        assert_eq!(before, (6, 0x82, 0x83));
+
+        m.cpu_write(0xA000, 1);
+        set_chr(&mut m, 9, 10, 11, 12);
+        m.ppu_fetch(0x0FD8);
+        m.ppu_fetch(0x1FE8);
+        assert_ne!(snapshot(&mut m), before);
+
+        let mut r = Reader::new(&bytes);
+        m.load_state(&mut r).unwrap();
+        assert_eq!(r.remaining(), 0);
+        assert_eq!(snapshot(&mut m), before);
+        assert_eq!(m.cpu_read(0x7000), 0xAB);
+        let mut again = Writer::new();
+        m.save_state(&mut again);
+        assert_eq!(again.into_bytes(), bytes);
+    }
+}

--- a/src/cartridge/mapper11.rs
+++ b/src/cartridge/mapper11.rs
@@ -1,0 +1,214 @@
+//! Mapper 11 (Color Dreams).
+//!
+//! Used by the unlicensed Color Dreams and Wisdom Tree catalogue (Crystal
+//! Mines, Bible Adventures, Menace Beach).
+//!
+//! One register, written anywhere in $8000-$FFFF:
+//!   bits 0-1  32 KB PRG bank for $8000-$FFFF
+//!   bits 2-3  lockout defeat, ignored
+//!   bits 4-7  8 KB CHR bank for $0000-$1FFF
+//! Mirroring comes from the header. Bus conflicts are not modelled.
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper11 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+    mirroring: Mirroring,
+    prg_bank: u8,
+    chr_bank: u8,
+}
+
+impl Mapper11 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mapper11 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            mirroring,
+            prg_bank: 0,
+            chr_bank: 0,
+        }
+    }
+
+    fn chr_offset(&self, addr: u16) -> usize {
+        self.chr_bank as usize * 0x2000 + (addr & 0x1FFF) as usize
+    }
+}
+
+impl Mapper for Mapper11 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xFFFF => {
+                let offset = self.prg_bank as usize * 0x8000 + (addr - 0x8000) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0x8000..=0xFFFF => {
+                self.prg_bank = value & 0x03;
+                self.chr_bank = value >> 4;
+            }
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_peek(&self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        let offset = self.chr_offset(addr);
+        self.chr.write(offset, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        self.mirroring
+    }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
+
+    // State: mirroring u8, prg_bank u8, chr_bank u8, PRG RAM 8 KB, CHR.
+    fn save_state(&self, w: &mut crate::state::Writer) {
+        w.u8(super::mapper::mirroring_to_u8(self.mirroring));
+        w.u8(self.prg_bank);
+        w.u8(self.chr_bank);
+        w.bytes(&self.prg_ram);
+        self.chr.save_state(w);
+    }
+
+    fn load_state(&mut self, r: &mut crate::state::Reader) -> Result<(), crate::state::StateError> {
+        self.mirroring = super::mapper::mirroring_from_u8(r.u8()?)?;
+        self.prg_bank = r.u8()?;
+        self.chr_bank = r.u8()?;
+        r.bytes(&mut self.prg_ram)?;
+        self.chr.load_state(r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    /// 4 x 32 KB PRG, 16 x 8 KB CHR (tagged 0x80 | bank to tell them apart).
+    fn color_dreams() -> Mapper11 {
+        let chr: Vec<u8> = tagged_rom(16, 0x2000).iter().map(|b| b | 0x80).collect();
+        Mapper11::new(tagged_rom(4, 0x8000), chr, Mirroring::Vertical)
+    }
+
+    #[test]
+    fn power_on_is_bank_0() {
+        let mut m = color_dreams();
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xFFFF), 0);
+        assert_eq!(m.ppu_read(0x0000), 0x80);
+    }
+
+    #[test]
+    fn prg_bank_from_bits_0_1() {
+        let mut m = color_dreams();
+        for bank in 0..4u8 {
+            m.cpu_write(0x8000, bank);
+            assert_eq!(m.cpu_read(0x8000), bank);
+            assert_eq!(m.cpu_read(0xFFFF), bank);
+        }
+        // Bits 2-3 (lockout defeat) do not reach the PRG bank.
+        m.cpu_write(0x8000, 0x0D);
+        assert_eq!(m.cpu_read(0x8000), 1);
+    }
+
+    #[test]
+    fn chr_bank_from_bits_4_7() {
+        let mut m = color_dreams();
+        for bank in 0..16u8 {
+            m.cpu_write(0xC000, bank << 4);
+            assert_eq!(m.ppu_read(0x0000), 0x80 | bank);
+            assert_eq!(m.ppu_read(0x1FFF), 0x80 | bank);
+            assert_eq!(m.ppu_peek(0x1000), 0x80 | bank);
+        }
+    }
+
+    #[test]
+    fn prg_and_chr_fields_are_independent() {
+        let mut m = color_dreams();
+        m.cpu_write(0x8000, 0x52);
+        assert_eq!(m.cpu_read(0x8000), 2);
+        assert_eq!(m.ppu_read(0x0000), 0x85);
+    }
+
+    #[test]
+    fn banks_wrap_to_image_size() {
+        let mut m = Mapper11::new(
+            tagged_rom(2, 0x8000),
+            tagged_rom(2, 0x2000),
+            Mirroring::Horizontal,
+        );
+        m.cpu_write(0x8000, 0x33);
+        assert_eq!(m.cpu_read(0x8000), 1);
+        assert_eq!(m.ppu_read(0x0000), 1);
+    }
+
+    #[test]
+    fn mirroring_comes_from_header() {
+        let m = color_dreams();
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        let h = Mapper11::new(tagged_rom(1, 0x8000), vec![], Mirroring::Horizontal);
+        assert_eq!(h.mirroring(), Mirroring::Horizontal);
+    }
+
+    #[test]
+    fn chr_ram_board_ignores_bank_bits() {
+        let mut m = Mapper11::new(tagged_rom(1, 0x8000), vec![], Mirroring::Horizontal);
+        m.ppu_write(0x0010, 0x5A);
+        m.cpu_write(0x8000, 0x30);
+        assert_eq!(m.ppu_read(0x0010), 0x5A);
+    }
+
+    #[test]
+    fn save_state_round_trips_banks() {
+        use crate::state::{Reader, Writer};
+        let mut m = color_dreams();
+        m.cpu_write(0x8000, 0x72);
+        m.cpu_write(0x6100, 0x33);
+        let mut w = Writer::new();
+        m.save_state(&mut w);
+        let bytes = w.into_bytes();
+
+        m.cpu_write(0x8000, 0x21);
+        assert_eq!(m.cpu_read(0x8000), 1);
+        assert_eq!(m.ppu_read(0x0000), 0x82);
+
+        let mut r = Reader::new(&bytes);
+        m.load_state(&mut r).unwrap();
+        assert_eq!(r.remaining(), 0);
+        assert_eq!(m.cpu_read(0x8000), 2);
+        assert_eq!(m.ppu_read(0x0000), 0x87);
+        assert_eq!(m.cpu_read(0x6100), 0x33);
+        let mut again = Writer::new();
+        m.save_state(&mut again);
+        assert_eq!(again.into_bytes(), bytes);
+    }
+}

--- a/src/cartridge/mapper66.rs
+++ b/src/cartridge/mapper66.rs
@@ -1,0 +1,205 @@
+//! Mapper 66 (GxROM: GNROM, MHROM).
+//!
+//! Used by Super Mario Bros / Duck Hunt, Dragon Power, Gumshoe, Doraemon.
+//!
+//! One register, written anywhere in $8000-$FFFF:
+//!   bits 0-1  8 KB CHR bank for $0000-$1FFF
+//!   bits 4-5  32 KB PRG bank for $8000-$FFFF
+//! Mirroring comes from the header. Bus conflicts are not modelled.
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper66 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+    mirroring: Mirroring,
+    prg_bank: u8,
+    chr_bank: u8,
+}
+
+impl Mapper66 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mapper66 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            mirroring,
+            prg_bank: 0,
+            chr_bank: 0,
+        }
+    }
+
+    fn chr_offset(&self, addr: u16) -> usize {
+        self.chr_bank as usize * 0x2000 + (addr & 0x1FFF) as usize
+    }
+}
+
+impl Mapper for Mapper66 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xFFFF => {
+                let offset = self.prg_bank as usize * 0x8000 + (addr - 0x8000) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0x8000..=0xFFFF => {
+                self.chr_bank = value & 0x03;
+                self.prg_bank = (value >> 4) & 0x03;
+            }
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_peek(&self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        let offset = self.chr_offset(addr);
+        self.chr.write(offset, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        self.mirroring
+    }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
+
+    // State: mirroring u8, prg_bank u8, chr_bank u8, PRG RAM 8 KB, CHR.
+    fn save_state(&self, w: &mut crate::state::Writer) {
+        w.u8(super::mapper::mirroring_to_u8(self.mirroring));
+        w.u8(self.prg_bank);
+        w.u8(self.chr_bank);
+        w.bytes(&self.prg_ram);
+        self.chr.save_state(w);
+    }
+
+    fn load_state(&mut self, r: &mut crate::state::Reader) -> Result<(), crate::state::StateError> {
+        self.mirroring = super::mapper::mirroring_from_u8(r.u8()?)?;
+        self.prg_bank = r.u8()?;
+        self.chr_bank = r.u8()?;
+        r.bytes(&mut self.prg_ram)?;
+        self.chr.load_state(r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    /// 4 x 32 KB PRG, 4 x 8 KB CHR (tagged 0x80 | bank).
+    fn gxrom() -> Mapper66 {
+        let chr: Vec<u8> = tagged_rom(4, 0x2000).iter().map(|b| b | 0x80).collect();
+        Mapper66::new(tagged_rom(4, 0x8000), chr, Mirroring::Horizontal)
+    }
+
+    #[test]
+    fn power_on_is_bank_0() {
+        let mut m = gxrom();
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xFFFF), 0);
+        assert_eq!(m.ppu_read(0x0000), 0x80);
+    }
+
+    #[test]
+    fn prg_bank_from_bits_4_5() {
+        let mut m = gxrom();
+        for bank in 0..4u8 {
+            m.cpu_write(0x8000, bank << 4);
+            assert_eq!(m.cpu_read(0x8000), bank);
+            assert_eq!(m.cpu_read(0xBFFF), bank);
+            assert_eq!(m.cpu_read(0xFFFF), bank);
+        }
+        // Bits 6-7 and 2-3 are not part of either field.
+        m.cpu_write(0x8000, 0xCC);
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.ppu_read(0x0000), 0x80);
+    }
+
+    #[test]
+    fn chr_bank_from_bits_0_1() {
+        let mut m = gxrom();
+        for bank in 0..4u8 {
+            m.cpu_write(0xFFFF, bank);
+            assert_eq!(m.ppu_read(0x0000), 0x80 | bank);
+            assert_eq!(m.ppu_read(0x1FFF), 0x80 | bank);
+            assert_eq!(m.ppu_peek(0x1000), 0x80 | bank);
+        }
+    }
+
+    #[test]
+    fn prg_and_chr_fields_are_independent() {
+        let mut m = gxrom();
+        m.cpu_write(0x8000, 0x21);
+        assert_eq!(m.cpu_read(0x8000), 2);
+        assert_eq!(m.ppu_read(0x0000), 0x81);
+    }
+
+    #[test]
+    fn banks_wrap_to_image_size() {
+        let mut m = Mapper66::new(
+            tagged_rom(2, 0x8000),
+            tagged_rom(2, 0x2000),
+            Mirroring::Horizontal,
+        );
+        m.cpu_write(0x8000, 0x33);
+        assert_eq!(m.cpu_read(0x8000), 1);
+        assert_eq!(m.ppu_read(0x0000), 1);
+    }
+
+    #[test]
+    fn mirroring_comes_from_header() {
+        assert_eq!(gxrom().mirroring(), Mirroring::Horizontal);
+        let v = Mapper66::new(tagged_rom(1, 0x8000), vec![], Mirroring::Vertical);
+        assert_eq!(v.mirroring(), Mirroring::Vertical);
+    }
+
+    #[test]
+    fn save_state_round_trips_banks() {
+        use crate::state::{Reader, Writer};
+        let mut m = gxrom();
+        m.cpu_write(0x8000, 0x32);
+        m.cpu_write(0x7FFF, 0x44);
+        let mut w = Writer::new();
+        m.save_state(&mut w);
+        let bytes = w.into_bytes();
+
+        m.cpu_write(0x8000, 0x11);
+        assert_eq!(m.cpu_read(0x8000), 1);
+        assert_eq!(m.ppu_read(0x0000), 0x81);
+
+        let mut r = Reader::new(&bytes);
+        m.load_state(&mut r).unwrap();
+        assert_eq!(r.remaining(), 0);
+        assert_eq!(m.cpu_read(0x8000), 3);
+        assert_eq!(m.ppu_read(0x0000), 0x82);
+        assert_eq!(m.cpu_read(0x7FFF), 0x44);
+        let mut again = Writer::new();
+        m.save_state(&mut again);
+        assert_eq!(again.into_bytes(), bytes);
+    }
+}

--- a/src/cartridge/mapper69.rs
+++ b/src/cartridge/mapper69.rs
@@ -1,0 +1,481 @@
+//! Mapper 69 (Sunsoft FME-7 / 5A / 5B).
+//!
+//! Used by Batman: Return of the Joker, Gimmick!, Hebereke, Gremlins 2.
+//!
+//! Two registers: $8000-$9FFF selects a command (bits 0-3) and $A000-$BFFF
+//! writes its parameter. $C000-$FFFF is the 5B audio chip, not modelled.
+//!
+//!   $0-$7  1 KB CHR bank for PPU $0000 + n * $400
+//!   $8     $6000-$7FFF: "ERbB BBBB". R = 1 selects PRG RAM (E = 1 enables
+//!          it, otherwise the range is open bus), R = 0 maps 8 KB PRG ROM
+//!          bank bBBBBB
+//!   $9-$B  8 KB PRG ROM bank (bits 0-5) at $8000, $A000, $C000
+//!          $E000-$FFFF is fixed to the last 8 KB bank
+//!   $C     mirroring (bits 0-1): 0 horizontal, 1 vertical,
+//!          2 single-screen lower, 3 single-screen upper
+//!   $D     IRQ control: bit 0 enables the IRQ output, bit 7 enables the
+//!          counter. Every write acknowledges a pending IRQ
+//!   $E/$F  IRQ counter low / high byte
+//!
+//! The 16-bit counter decrements once per CPU cycle while enabled
+//! (`cpu_clock`, called from `System::tick`) and raises the IRQ on the
+//! $0000 to $FFFF wrap when the IRQ output is enabled. It keeps counting
+//! after the wrap; the IRQ line stays high until a command $D write.
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper69 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+
+    command: u8,
+    chr_banks: [u8; 8],
+    /// Raw command $8 parameter: RAM enable, RAM/ROM select, bank.
+    prg_6000: u8,
+    /// 8 KB PRG banks for $8000, $A000, $C000.
+    prg_banks: [u8; 3],
+    mirroring: u8,
+
+    irq_enabled: bool,
+    irq_counter_enabled: bool,
+    irq_counter: u16,
+    irq_pending: bool,
+}
+
+impl Mapper69 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mapper69 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            command: 0,
+            chr_banks: [0; 8],
+            prg_6000: 0,
+            prg_banks: [0; 3],
+            mirroring: match mirroring {
+                Mirroring::Vertical => 1,
+                Mirroring::SingleScreenLower => 2,
+                Mirroring::SingleScreenUpper => 3,
+                _ => 0,
+            },
+            irq_enabled: false,
+            irq_counter_enabled: false,
+            irq_counter: 0,
+            irq_pending: false,
+        }
+    }
+
+    fn chr_offset(&self, addr: u16) -> usize {
+        let slot = ((addr & 0x1FFF) / 0x400) as usize;
+        self.chr_banks[slot] as usize * 0x400 + (addr & 0x3FF) as usize
+    }
+
+    fn ram_selected(&self) -> bool {
+        self.prg_6000 & 0x40 != 0
+    }
+
+    fn ram_enabled(&self) -> bool {
+        self.prg_6000 & 0x80 != 0
+    }
+
+    fn write_parameter(&mut self, value: u8) {
+        match self.command {
+            0x0..=0x7 => self.chr_banks[self.command as usize] = value,
+            0x8 => self.prg_6000 = value,
+            0x9..=0xB => self.prg_banks[(self.command - 0x9) as usize] = value & 0x3F,
+            0xC => self.mirroring = value & 0x03,
+            0xD => {
+                self.irq_enabled = value & 0x01 != 0;
+                self.irq_counter_enabled = value & 0x80 != 0;
+                self.irq_pending = false;
+            }
+            0xE => self.irq_counter = (self.irq_counter & 0xFF00) | value as u16,
+            0xF => self.irq_counter = (self.irq_counter & 0x00FF) | ((value as u16) << 8),
+            _ => unreachable!("command is masked to four bits"),
+        }
+    }
+}
+
+impl Mapper for Mapper69 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => {
+                if self.ram_selected() {
+                    if self.ram_enabled() {
+                        self.prg_ram[(addr - 0x6000) as usize]
+                    } else {
+                        0
+                    }
+                } else {
+                    let bank = (self.prg_6000 & 0x3F) as usize;
+                    prg_read(&self.prg_rom, bank * 0x2000 + (addr - 0x6000) as usize)
+                }
+            }
+            0x8000..=0xDFFF => {
+                let slot = ((addr - 0x8000) / 0x2000) as usize;
+                let bank = self.prg_banks[slot] as usize;
+                prg_read(&self.prg_rom, bank * 0x2000 + (addr & 0x1FFF) as usize)
+            }
+            0xE000..=0xFFFF => {
+                let base = self.prg_rom.len().saturating_sub(0x2000);
+                prg_read(&self.prg_rom, base + (addr & 0x1FFF) as usize)
+            }
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => {
+                if self.ram_selected() && self.ram_enabled() {
+                    self.prg_ram[(addr - 0x6000) as usize] = value;
+                }
+            }
+            0x8000..=0x9FFF => self.command = value & 0x0F,
+            0xA000..=0xBFFF => self.write_parameter(value),
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_peek(&self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        let offset = self.chr_offset(addr);
+        self.chr.write(offset, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        match self.mirroring {
+            0 => Mirroring::Horizontal,
+            1 => Mirroring::Vertical,
+            2 => Mirroring::SingleScreenLower,
+            _ => Mirroring::SingleScreenUpper,
+        }
+    }
+
+    fn irq_pending(&self) -> bool {
+        self.irq_pending
+    }
+
+    fn clear_irq(&mut self) {
+        self.irq_pending = false;
+    }
+
+    fn cpu_clock(&mut self) {
+        if !self.irq_counter_enabled {
+            return;
+        }
+        let wraps = self.irq_counter == 0;
+        self.irq_counter = self.irq_counter.wrapping_sub(1);
+        if wraps && self.irq_enabled {
+            self.irq_pending = true;
+        }
+    }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
+
+    // State: command u8, chr_banks 8 x u8, prg_6000 u8, prg_banks 3 x u8,
+    // mirroring u8, irq_enabled bool, irq_counter_enabled bool,
+    // irq_counter u16, irq_pending bool, PRG RAM 8 KB, CHR.
+    fn save_state(&self, w: &mut crate::state::Writer) {
+        w.u8(self.command);
+        w.bytes(&self.chr_banks);
+        w.u8(self.prg_6000);
+        w.bytes(&self.prg_banks);
+        w.u8(self.mirroring);
+        w.bool(self.irq_enabled);
+        w.bool(self.irq_counter_enabled);
+        w.u16(self.irq_counter);
+        w.bool(self.irq_pending);
+        w.bytes(&self.prg_ram);
+        self.chr.save_state(w);
+    }
+
+    fn load_state(&mut self, r: &mut crate::state::Reader) -> Result<(), crate::state::StateError> {
+        self.command = r.u8()? & 0x0F;
+        r.bytes(&mut self.chr_banks)?;
+        self.prg_6000 = r.u8()?;
+        r.bytes(&mut self.prg_banks)?;
+        self.mirroring = r.u8()? & 0x03;
+        self.irq_enabled = r.bool()?;
+        self.irq_counter_enabled = r.bool()?;
+        self.irq_counter = r.u16()?;
+        self.irq_pending = r.bool()?;
+        r.bytes(&mut self.prg_ram)?;
+        self.chr.load_state(r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    /// 32 x 8 KB PRG, 64 x 1 KB CHR (tagged 0x80 | bank).
+    fn fme7() -> Mapper69 {
+        let chr: Vec<u8> = tagged_rom(64, 0x400).iter().map(|b| b | 0x80).collect();
+        Mapper69::new(tagged_rom(32, 0x2000), chr, Mirroring::Horizontal)
+    }
+
+    fn cmd(m: &mut Mapper69, command: u8, value: u8) {
+        m.cpu_write(0x8000, command);
+        m.cpu_write(0xA000, value);
+    }
+
+    #[test]
+    fn power_on_layout() {
+        let mut m = fme7();
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xA000), 0);
+        assert_eq!(m.cpu_read(0xC000), 0);
+        assert_eq!(m.cpu_read(0xE000), 31);
+        assert_eq!(m.cpu_read(0xFFFF), 31);
+        // Command 8 = 0: PRG ROM bank 0 at $6000.
+        assert_eq!(m.cpu_read(0x6000), 0);
+        assert_eq!(m.ppu_read(0x0000), 0x80);
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+        assert!(!m.irq_pending());
+    }
+
+    #[test]
+    fn chr_1k_banks() {
+        let mut m = fme7();
+        for slot in 0..8u8 {
+            cmd(&mut m, slot, 40 + slot);
+        }
+        for slot in 0..8u16 {
+            let addr = slot * 0x400;
+            assert_eq!(m.ppu_read(addr), 0x80 | (40 + slot as u8));
+            assert_eq!(m.ppu_read(addr + 0x3FF), 0x80 | (40 + slot as u8));
+            assert_eq!(m.ppu_peek(addr), m.ppu_read(addr));
+        }
+        // Wraps to the image size.
+        cmd(&mut m, 0, 65);
+        assert_eq!(m.ppu_read(0x0000), 0x81);
+    }
+
+    #[test]
+    fn prg_8k_banks_with_last_fixed() {
+        let mut m = fme7();
+        cmd(&mut m, 0x9, 3);
+        cmd(&mut m, 0xA, 7);
+        cmd(&mut m, 0xB, 12);
+        assert_eq!(m.cpu_read(0x8000), 3);
+        assert_eq!(m.cpu_read(0x9FFF), 3);
+        assert_eq!(m.cpu_read(0xA000), 7);
+        assert_eq!(m.cpu_read(0xC000), 12);
+        assert_eq!(m.cpu_read(0xDFFF), 12);
+        assert_eq!(m.cpu_read(0xE000), 31);
+        // Bits 6-7 are ignored; out-of-range banks wrap.
+        cmd(&mut m, 0x9, 0xC5);
+        assert_eq!(m.cpu_read(0x8000), 5);
+        cmd(&mut m, 0x9, 33);
+        assert_eq!(m.cpu_read(0x8000), 1);
+    }
+
+    #[test]
+    fn command_register_uses_low_nibble_only() {
+        let mut m = fme7();
+        m.cpu_write(0x9FFF, 0xF9);
+        m.cpu_write(0xBFFF, 4);
+        assert_eq!(m.cpu_read(0x8000), 4);
+        // Audio registers are not mapper registers.
+        m.cpu_write(0xC000, 0xA);
+        m.cpu_write(0xE000, 9);
+        assert_eq!(m.cpu_read(0xA000), 0);
+    }
+
+    #[test]
+    fn slot_6000_rom_ram_and_open_bus() {
+        let mut m = fme7();
+        // ROM bank at $6000.
+        cmd(&mut m, 0x8, 0x05);
+        assert_eq!(m.cpu_read(0x6000), 5);
+        assert_eq!(m.cpu_read(0x7FFF), 5);
+        m.cpu_write(0x6000, 0x11); // ROM: no effect on RAM
+                                   // RAM selected and enabled.
+        cmd(&mut m, 0x8, 0xC0);
+        assert_eq!(m.cpu_read(0x6000), 0);
+        m.cpu_write(0x6000, 0x42);
+        assert_eq!(m.cpu_read(0x6000), 0x42);
+        assert_eq!(m.prg_ram().unwrap()[0], 0x42);
+        // RAM selected but disabled: open bus, writes dropped.
+        cmd(&mut m, 0x8, 0x40);
+        assert_eq!(m.cpu_read(0x6000), 0);
+        m.cpu_write(0x6000, 0x99);
+        cmd(&mut m, 0x8, 0xC0);
+        assert_eq!(m.cpu_read(0x6000), 0x42);
+        // Bank bits are ignored while RAM is selected.
+        cmd(&mut m, 0x8, 0xC7);
+        assert_eq!(m.cpu_peek(0x6000), 0x42);
+    }
+
+    #[test]
+    fn mirroring_command() {
+        let mut m = fme7();
+        cmd(&mut m, 0xC, 0);
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+        cmd(&mut m, 0xC, 1);
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        cmd(&mut m, 0xC, 2);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenLower);
+        cmd(&mut m, 0xC, 0xFF);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenUpper);
+        let v = Mapper69::new(tagged_rom(4, 0x2000), vec![], Mirroring::Vertical);
+        assert_eq!(v.mirroring(), Mirroring::Vertical);
+    }
+
+    #[test]
+    fn irq_fires_on_wrap_after_exact_cycle_count() {
+        let mut m = fme7();
+        cmd(&mut m, 0xE, 0x02);
+        cmd(&mut m, 0xF, 0x00);
+        cmd(&mut m, 0xD, 0x81);
+        // 2 -> 1 -> 0 -> FFFF: the third clock fires.
+        m.cpu_clock();
+        m.cpu_clock();
+        assert!(!m.irq_pending());
+        m.cpu_clock();
+        assert!(m.irq_pending());
+        assert_eq!(m.irq_counter, 0xFFFF);
+        // Keeps counting; the line stays asserted until acknowledged.
+        m.cpu_clock();
+        assert_eq!(m.irq_counter, 0xFFFE);
+        assert!(m.irq_pending());
+    }
+
+    #[test]
+    fn irq_counter_takes_high_byte() {
+        let mut m = fme7();
+        cmd(&mut m, 0xE, 0x00);
+        cmd(&mut m, 0xF, 0x01);
+        cmd(&mut m, 0xD, 0x81);
+        for _ in 0..0x100 {
+            m.cpu_clock();
+        }
+        assert!(!m.irq_pending());
+        m.cpu_clock();
+        assert!(m.irq_pending());
+    }
+
+    #[test]
+    fn counter_disabled_does_not_count_and_irq_disabled_does_not_assert() {
+        let mut m = fme7();
+        cmd(&mut m, 0xE, 0);
+        cmd(&mut m, 0xF, 0);
+        // IRQ output on, counter off: nothing moves.
+        cmd(&mut m, 0xD, 0x01);
+        for _ in 0..10 {
+            m.cpu_clock();
+        }
+        assert_eq!(m.irq_counter, 0);
+        assert!(!m.irq_pending());
+        // Counter on, IRQ output off: wraps silently.
+        cmd(&mut m, 0xD, 0x80);
+        m.cpu_clock();
+        assert_eq!(m.irq_counter, 0xFFFF);
+        assert!(!m.irq_pending());
+    }
+
+    #[test]
+    fn command_d_write_acknowledges_and_clear_irq_works() {
+        let mut m = fme7();
+        cmd(&mut m, 0xE, 0);
+        cmd(&mut m, 0xF, 0);
+        cmd(&mut m, 0xD, 0x81);
+        m.cpu_clock();
+        assert!(Mapper::irq_pending(&m));
+        cmd(&mut m, 0xD, 0x81);
+        assert!(!Mapper::irq_pending(&m));
+        m.cpu_clock();
+        assert!(!Mapper::irq_pending(&m), "no wrap this cycle");
+        cmd(&mut m, 0xE, 0);
+        cmd(&mut m, 0xF, 0);
+        m.cpu_clock();
+        assert!(Mapper::irq_pending(&m));
+        m.clear_irq();
+        assert!(!Mapper::irq_pending(&m));
+    }
+
+    #[test]
+    fn save_state_round_trips_banks_and_irq_counter() {
+        use crate::state::{Reader, Writer};
+        let mut m = fme7();
+        for slot in 0..8u8 {
+            cmd(&mut m, slot, 10 + slot);
+        }
+        cmd(&mut m, 0x8, 0xC0);
+        m.cpu_write(0x6010, 0x5A);
+        cmd(&mut m, 0x9, 3);
+        cmd(&mut m, 0xA, 7);
+        cmd(&mut m, 0xB, 12);
+        cmd(&mut m, 0xC, 1);
+        cmd(&mut m, 0xE, 0x05);
+        cmd(&mut m, 0xF, 0x00);
+        cmd(&mut m, 0xD, 0x81);
+        m.cpu_clock();
+        m.cpu_clock(); // counter = 3
+        let mut w = Writer::new();
+        m.save_state(&mut w);
+        let bytes = w.into_bytes();
+        let snapshot = |m: &mut Mapper69| {
+            let mut v = Vec::new();
+            for addr in (0x6000..=0xFFFF).step_by(0x2000) {
+                v.push(m.cpu_read(addr));
+            }
+            for addr in (0x0000..0x2000).step_by(0x400) {
+                v.push(m.ppu_read(addr));
+            }
+            v
+        };
+        let before = snapshot(&mut m);
+
+        for slot in 0..8u8 {
+            cmd(&mut m, slot, 20 + slot);
+        }
+        cmd(&mut m, 0x8, 0x02);
+        cmd(&mut m, 0x9, 1);
+        cmd(&mut m, 0xC, 3);
+        for _ in 0..4 {
+            m.cpu_clock();
+        }
+        assert!(m.irq_pending());
+        assert_ne!(snapshot(&mut m), before);
+
+        let mut r = Reader::new(&bytes);
+        m.load_state(&mut r).unwrap();
+        assert_eq!(r.remaining(), 0);
+        assert_eq!(snapshot(&mut m), before);
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        assert_eq!(m.cpu_read(0x6010), 0x5A);
+        assert!(!m.irq_pending());
+        // Counter was 3: three clocks reach 0, the fourth wraps.
+        for _ in 0..3 {
+            m.cpu_clock();
+        }
+        assert!(!m.irq_pending());
+        m.cpu_clock();
+        assert!(m.irq_pending());
+        let mut again = Writer::new();
+        m.save_state(&mut again);
+        assert_ne!(again.into_bytes(), bytes, "the IRQ state moved on");
+    }
+}

--- a/src/cartridge/mapper7.rs
+++ b/src/cartridge/mapper7.rs
@@ -1,0 +1,194 @@
+//! Mapper 7 (AxROM: ANROM, AMROM, AOROM).
+//!
+//! Used by Battletoads, Marble Madness, Wizards and Warriors, Cobra Triangle.
+//!
+//! One register, written anywhere in $8000-$FFFF:
+//!   bits 0-2  32 KB PRG bank for $8000-$FFFF
+//!   bit 4     single-screen nametable (0 = lower 1 KB page, 1 = upper)
+//! CHR is 8 KB RAM, not banked. The header mirroring bits are ignored
+//! because the register owns the nametable selection. Power-on is bank 0,
+//! lower page.
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+pub struct Mapper7 {
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+    prg_bank: u8,
+    upper_nametable: bool,
+}
+
+impl Mapper7 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, _mirroring: Mirroring) -> Self {
+        Mapper7 {
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            prg_bank: 0,
+            upper_nametable: false,
+        }
+    }
+}
+
+impl Mapper for Mapper7 {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize],
+            0x8000..=0xFFFF => {
+                let offset = self.prg_bank as usize * 0x8000 + (addr - 0x8000) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0x8000..=0xFFFF => {
+                self.prg_bank = value & 0x07;
+                self.upper_nametable = value & 0x10 != 0;
+            }
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read((addr & 0x1FFF) as usize)
+    }
+
+    fn ppu_peek(&self, addr: u16) -> u8 {
+        self.chr.read((addr & 0x1FFF) as usize)
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        self.chr.write((addr & 0x1FFF) as usize, value);
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        if self.upper_nametable {
+            Mirroring::SingleScreenUpper
+        } else {
+            Mirroring::SingleScreenLower
+        }
+    }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
+
+    // State: prg_bank u8, upper_nametable bool, PRG RAM 8 KB, CHR.
+    fn save_state(&self, w: &mut crate::state::Writer) {
+        w.u8(self.prg_bank);
+        w.bool(self.upper_nametable);
+        w.bytes(&self.prg_ram);
+        self.chr.save_state(w);
+    }
+
+    fn load_state(&mut self, r: &mut crate::state::Reader) -> Result<(), crate::state::StateError> {
+        self.prg_bank = r.u8()?;
+        self.upper_nametable = r.bool()?;
+        r.bytes(&mut self.prg_ram)?;
+        self.chr.load_state(r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    fn axrom() -> Mapper7 {
+        Mapper7::new(tagged_rom(8, 0x8000), vec![], Mirroring::Horizontal)
+    }
+
+    #[test]
+    fn power_on_is_bank_0_lower_nametable() {
+        let mut m = axrom();
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xFFFF), 0);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenLower);
+    }
+
+    #[test]
+    fn prg_bank_from_bits_0_to_2_covers_32k() {
+        let mut m = axrom();
+        for bank in 0..8u8 {
+            m.cpu_write(0x8000, bank);
+            assert_eq!(m.cpu_read(0x8000), bank);
+            assert_eq!(m.cpu_read(0xBFFF), bank);
+            assert_eq!(m.cpu_read(0xC000), bank);
+            assert_eq!(m.cpu_read(0xFFFF), bank);
+        }
+        // Bit 3 and above do not reach the bank number.
+        m.cpu_write(0xFFFF, 0xE9);
+        assert_eq!(m.cpu_read(0x8000), 1);
+    }
+
+    #[test]
+    fn bank_wraps_to_rom_size() {
+        let mut m = Mapper7::new(tagged_rom(2, 0x8000), vec![], Mirroring::Vertical);
+        m.cpu_write(0x8000, 5);
+        assert_eq!(m.cpu_read(0x8000), 1);
+    }
+
+    #[test]
+    fn bit_4_selects_single_screen_page() {
+        let mut m = axrom();
+        m.cpu_write(0x8000, 0x10);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenUpper);
+        m.cpu_write(0x8000, 0x07);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenLower);
+        // Bit 3 is not the nametable bit.
+        m.cpu_write(0x8000, 0x08);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenLower);
+    }
+
+    #[test]
+    fn chr_ram_is_writable_and_unbanked() {
+        let mut m = axrom();
+        m.ppu_write(0x1FFF, 0x42);
+        assert_eq!(m.ppu_read(0x1FFF), 0x42);
+        assert_eq!(m.ppu_peek(0x1FFF), 0x42);
+        m.cpu_write(0x8000, 3);
+        assert_eq!(m.ppu_read(0x1FFF), 0x42);
+    }
+
+    #[test]
+    fn save_state_round_trips_bank_page_and_chr_ram() {
+        use crate::state::{Reader, Writer};
+        let mut m = axrom();
+        m.cpu_write(0x8000, 0x15);
+        m.ppu_write(0x0123, 0x99);
+        m.cpu_write(0x6000, 0x77);
+        let mut w = Writer::new();
+        m.save_state(&mut w);
+        let bytes = w.into_bytes();
+
+        m.cpu_write(0x8000, 0x02);
+        m.ppu_write(0x0123, 0);
+        assert_eq!(m.cpu_read(0x8000), 2);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenLower);
+
+        let mut r = Reader::new(&bytes);
+        m.load_state(&mut r).unwrap();
+        assert_eq!(r.remaining(), 0);
+        assert_eq!(m.cpu_read(0x8000), 5);
+        assert_eq!(m.mirroring(), Mirroring::SingleScreenUpper);
+        assert_eq!(m.ppu_read(0x0123), 0x99);
+        assert_eq!(m.cpu_read(0x6000), 0x77);
+        let mut again = Writer::new();
+        m.save_state(&mut again);
+        assert_eq!(again.into_bytes(), bytes);
+    }
+}

--- a/src/cartridge/mapper9.rs
+++ b/src/cartridge/mapper9.rs
@@ -1,0 +1,460 @@
+//! Mapper 9 (MMC2 / PNROM), and the core shared with mapper 10 (MMC4).
+//!
+//! Used by Mike Tyson's Punch-Out.
+//!
+//! Registers (CPU addresses, data bits shown):
+//!   $A000-$AFFF  PRG bank (bits 0-3): 8 KB at $8000-$9FFF; $A000-$FFFF is
+//!                fixed to the last three 8 KB banks
+//!   $B000-$BFFF  4 KB CHR bank for $0000-$0FFF while latch 0 = $FD
+//!   $C000-$CFFF  4 KB CHR bank for $0000-$0FFF while latch 0 = $FE
+//!   $D000-$DFFF  4 KB CHR bank for $1000-$1FFF while latch 1 = $FD
+//!   $E000-$EFFF  4 KB CHR bank for $1000-$1FFF while latch 1 = $FE
+//!   $F000-$FFFF  mirroring (bit 0: 0 = vertical, 1 = horizontal)
+//!
+//! The latches are flipped by the PPU address bus, which the PPU reports
+//! through `Mapper::ppu_fetch` after each pattern read (nesdev "MMC2"):
+//!   read of $0FD8            latch 0 = $FD    (MMC4: $0FD8-$0FDF)
+//!   read of $0FE8            latch 0 = $FE    (MMC4: $0FE8-$0FEF)
+//!   read of $1FD8-$1FDF      latch 1 = $FD
+//!   read of $1FE8-$1FEF      latch 1 = $FE
+//! The byte at the triggering address comes from the bank selected before
+//! the flip; the next fetch uses the new bank. `ppu_peek` never flips.
+//!
+//! MMC4 (Fire Emblem) differs only in PRG (16 KB at $8000-$BFFF, last 16 KB
+//! fixed) and in latch 0 responding to the whole $xFD8-$xFDF row range, so
+//! `mapper10.rs` wraps `Mmc2Core` with `Kind::Mmc4`.
+
+use super::mapper::{prg_read, Chr, Mapper};
+use super::Mirroring;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Kind {
+    Mmc2,
+    Mmc4,
+}
+
+pub(crate) struct Mmc2Core {
+    kind: Kind,
+    prg_rom: Vec<u8>,
+    chr: Chr,
+    prg_ram: [u8; 0x2000],
+    prg_bank: u8,
+    /// 4 KB CHR banks used while the table's latch is $FD, per table.
+    chr_fd: [u8; 2],
+    /// 4 KB CHR banks used while the table's latch is $FE, per table.
+    chr_fe: [u8; 2],
+    /// Per pattern table: true while the latch holds $FE.
+    latch_fe: [bool; 2],
+    /// 0 = vertical, 1 = horizontal.
+    mirroring: u8,
+}
+
+impl Mmc2Core {
+    pub fn new(kind: Kind, prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mmc2Core {
+            kind,
+            prg_rom,
+            chr: Chr::new(chr_rom),
+            prg_ram: [0; 0x2000],
+            prg_bank: 0,
+            chr_fd: [0; 2],
+            chr_fe: [0; 2],
+            // Power-on latch state is not specified; $FE is the common
+            // emulator choice and games set the banks before rendering.
+            latch_fe: [true; 2],
+            mirroring: match mirroring {
+                Mirroring::Horizontal => 1,
+                _ => 0,
+            },
+        }
+    }
+
+    fn chr_offset(&self, addr: u16) -> usize {
+        let table = ((addr >> 12) & 1) as usize;
+        let bank = if self.latch_fe[table] {
+            self.chr_fe[table]
+        } else {
+            self.chr_fd[table]
+        };
+        bank as usize * 0x1000 + (addr & 0x0FFF) as usize
+    }
+}
+
+impl Mapper for Mmc2Core {
+    fn cpu_read(&mut self, addr: u16) -> u8 {
+        self.cpu_peek(addr)
+    }
+
+    fn cpu_peek(&self, addr: u16) -> u8 {
+        match (self.kind, addr) {
+            (_, 0x6000..=0x7FFF) => self.prg_ram[(addr - 0x6000) as usize],
+            (Kind::Mmc2, 0x8000..=0x9FFF) => {
+                let offset = self.prg_bank as usize * 0x2000 + (addr - 0x8000) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            (Kind::Mmc2, 0xA000..=0xFFFF) => {
+                let base = self.prg_rom.len().saturating_sub(0x6000);
+                prg_read(&self.prg_rom, base + (addr - 0xA000) as usize)
+            }
+            (Kind::Mmc4, 0x8000..=0xBFFF) => {
+                let offset = self.prg_bank as usize * 0x4000 + (addr - 0x8000) as usize;
+                prg_read(&self.prg_rom, offset)
+            }
+            (Kind::Mmc4, 0xC000..=0xFFFF) => {
+                let base = self.prg_rom.len().saturating_sub(0x4000);
+                prg_read(&self.prg_rom, base + (addr - 0xC000) as usize)
+            }
+            _ => 0,
+        }
+    }
+
+    fn cpu_write(&mut self, addr: u16, value: u8) {
+        match addr {
+            0x6000..=0x7FFF => self.prg_ram[(addr - 0x6000) as usize] = value,
+            0xA000..=0xAFFF => self.prg_bank = value & 0x0F,
+            0xB000..=0xBFFF => self.chr_fd[0] = value & 0x1F,
+            0xC000..=0xCFFF => self.chr_fe[0] = value & 0x1F,
+            0xD000..=0xDFFF => self.chr_fd[1] = value & 0x1F,
+            0xE000..=0xEFFF => self.chr_fe[1] = value & 0x1F,
+            0xF000..=0xFFFF => self.mirroring = value & 0x01,
+            _ => {}
+        }
+    }
+
+    fn ppu_read(&mut self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_peek(&self, addr: u16) -> u8 {
+        self.chr.read(self.chr_offset(addr))
+    }
+
+    fn ppu_write(&mut self, addr: u16, value: u8) {
+        let offset = self.chr_offset(addr);
+        self.chr.write(offset, value);
+    }
+
+    fn ppu_fetch(&mut self, addr: u16) {
+        // MMC2 latch 0 only decodes row 0 of the tile; MMC4 latch 0 and
+        // latch 1 on both chips decode all eight rows.
+        let fe = match (self.kind, addr) {
+            (Kind::Mmc2, 0x0FD8) => false,
+            (Kind::Mmc2, 0x0FE8) => true,
+            (Kind::Mmc4, 0x0FD8..=0x0FDF) => false,
+            (Kind::Mmc4, 0x0FE8..=0x0FEF) => true,
+            (_, 0x1FD8..=0x1FDF) => false,
+            (_, 0x1FE8..=0x1FEF) => true,
+            _ => return,
+        };
+        self.latch_fe[((addr >> 12) & 1) as usize] = fe;
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        if self.mirroring == 0 {
+            Mirroring::Vertical
+        } else {
+            Mirroring::Horizontal
+        }
+    }
+
+    fn prg_ram(&self) -> Option<&[u8]> {
+        Some(&self.prg_ram)
+    }
+
+    fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+        Some(&mut self.prg_ram)
+    }
+
+    // State: prg_bank u8, chr_fd 2 x u8, chr_fe 2 x u8, latch_fe 2 x bool,
+    // mirroring u8, PRG RAM 8 KB, CHR.
+    fn save_state(&self, w: &mut crate::state::Writer) {
+        w.u8(self.prg_bank);
+        w.bytes(&self.chr_fd);
+        w.bytes(&self.chr_fe);
+        w.bool(self.latch_fe[0]);
+        w.bool(self.latch_fe[1]);
+        w.u8(self.mirroring);
+        w.bytes(&self.prg_ram);
+        self.chr.save_state(w);
+    }
+
+    fn load_state(&mut self, r: &mut crate::state::Reader) -> Result<(), crate::state::StateError> {
+        self.prg_bank = r.u8()?;
+        r.bytes(&mut self.chr_fd)?;
+        r.bytes(&mut self.chr_fe)?;
+        self.latch_fe[0] = r.bool()?;
+        self.latch_fe[1] = r.bool()?;
+        self.mirroring = r.u8()?;
+        r.bytes(&mut self.prg_ram)?;
+        self.chr.load_state(r)
+    }
+}
+
+pub struct Mapper9(Mmc2Core);
+
+impl Mapper9 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
+        Mapper9(Mmc2Core::new(Kind::Mmc2, prg_rom, chr_rom, mirroring))
+    }
+}
+
+/// Forward every `Mapper` method of a newtype around `Mmc2Core`.
+macro_rules! forward_mmc2_core {
+    ($name:ident) => {
+        impl Mapper for $name {
+            fn cpu_read(&mut self, addr: u16) -> u8 {
+                self.0.cpu_read(addr)
+            }
+            fn cpu_write(&mut self, addr: u16, value: u8) {
+                self.0.cpu_write(addr, value)
+            }
+            fn cpu_peek(&self, addr: u16) -> u8 {
+                self.0.cpu_peek(addr)
+            }
+            fn ppu_read(&mut self, addr: u16) -> u8 {
+                self.0.ppu_read(addr)
+            }
+            fn ppu_write(&mut self, addr: u16, value: u8) {
+                self.0.ppu_write(addr, value)
+            }
+            fn ppu_peek(&self, addr: u16) -> u8 {
+                self.0.ppu_peek(addr)
+            }
+            fn ppu_fetch(&mut self, addr: u16) {
+                self.0.ppu_fetch(addr)
+            }
+            fn mirroring(&self) -> Mirroring {
+                self.0.mirroring()
+            }
+            fn prg_ram(&self) -> Option<&[u8]> {
+                self.0.prg_ram()
+            }
+            fn prg_ram_mut(&mut self) -> Option<&mut [u8]> {
+                self.0.prg_ram_mut()
+            }
+            fn save_state(&self, w: &mut crate::state::Writer) {
+                self.0.save_state(w)
+            }
+            fn load_state(
+                &mut self,
+                r: &mut crate::state::Reader,
+            ) -> Result<(), crate::state::StateError> {
+                self.0.load_state(r)
+            }
+        }
+    };
+}
+pub(crate) use forward_mmc2_core;
+
+forward_mmc2_core!(Mapper9);
+
+#[cfg(test)]
+mod tests {
+    use super::super::mapper::test_util::tagged_rom;
+    use super::*;
+
+    /// 16 x 8 KB PRG, 32 x 4 KB CHR (tagged 0x80 | bank).
+    fn mmc2() -> Mapper9 {
+        let chr: Vec<u8> = tagged_rom(32, 0x1000).iter().map(|b| b | 0x80).collect();
+        Mapper9::new(tagged_rom(16, 0x2000), chr, Mirroring::Vertical)
+    }
+
+    fn set_chr(m: &mut Mapper9, fd0: u8, fe0: u8, fd1: u8, fe1: u8) {
+        m.cpu_write(0xB000, fd0);
+        m.cpu_write(0xC000, fe0);
+        m.cpu_write(0xD000, fd1);
+        m.cpu_write(0xE000, fe1);
+    }
+
+    #[test]
+    fn prg_8k_switchable_with_last_three_fixed() {
+        let mut m = mmc2();
+        assert_eq!(m.cpu_read(0x8000), 0);
+        assert_eq!(m.cpu_read(0xA000), 13);
+        assert_eq!(m.cpu_read(0xC000), 14);
+        assert_eq!(m.cpu_read(0xE000), 15);
+        assert_eq!(m.cpu_read(0xFFFF), 15);
+        m.cpu_write(0xA000, 7);
+        assert_eq!(m.cpu_read(0x8000), 7);
+        assert_eq!(m.cpu_read(0x9FFF), 7);
+        assert_eq!(m.cpu_read(0xA000), 13);
+        // Only bits 0-3 are the bank.
+        m.cpu_write(0xAFFF, 0xF3);
+        assert_eq!(m.cpu_read(0x8000), 3);
+        // Writes below $A000 are not registers.
+        m.cpu_write(0x8000, 9);
+        assert_eq!(m.cpu_read(0x8000), 3);
+    }
+
+    #[test]
+    fn prg_bank_wraps_to_rom_size() {
+        let mut m = Mapper9::new(tagged_rom(4, 0x2000), vec![], Mirroring::Vertical);
+        m.cpu_write(0xA000, 6);
+        assert_eq!(m.cpu_read(0x8000), 2);
+        assert_eq!(m.cpu_read(0xA000), 1);
+        assert_eq!(m.cpu_read(0xE000), 3);
+    }
+
+    #[test]
+    fn chr_banks_follow_each_tables_latch() {
+        let mut m = mmc2();
+        set_chr(&mut m, 1, 2, 3, 4);
+        // Power-on latches are $FE.
+        assert_eq!(m.ppu_read(0x0000), 0x82);
+        assert_eq!(m.ppu_read(0x1000), 0x84);
+        m.ppu_fetch(0x0FD8);
+        assert_eq!(m.ppu_read(0x0000), 0x81);
+        assert_eq!(m.ppu_read(0x0FFF), 0x81);
+        assert_eq!(m.ppu_read(0x1000), 0x84, "latch 1 untouched");
+        m.ppu_fetch(0x1FD8);
+        assert_eq!(m.ppu_read(0x1000), 0x83);
+        assert_eq!(m.ppu_read(0x0000), 0x81, "latch 0 untouched");
+        m.ppu_fetch(0x0FE8);
+        m.ppu_fetch(0x1FE8);
+        assert_eq!(m.ppu_read(0x0000), 0x82);
+        assert_eq!(m.ppu_read(0x1000), 0x84);
+        // Registers take effect immediately for the active latch.
+        m.cpu_write(0xC000, 9);
+        assert_eq!(m.ppu_read(0x0000), 0x89);
+        m.cpu_write(0xB000, 10);
+        assert_eq!(m.ppu_read(0x0000), 0x89, "FD bank is not the active one");
+    }
+
+    #[test]
+    fn latch_0_decodes_row_0_only_on_mmc2() {
+        let mut m = mmc2();
+        set_chr(&mut m, 1, 2, 3, 4);
+        m.ppu_fetch(0x0FD8);
+        assert_eq!(m.ppu_read(0x0000), 0x81);
+        // Rows 1-7 of tile $FE do not flip latch 0 on the MMC2.
+        for row in 1..8u16 {
+            m.ppu_fetch(0x0FE8 + row);
+            assert_eq!(m.ppu_read(0x0000), 0x81, "row {row}");
+        }
+        m.ppu_fetch(0x0FE8);
+        assert_eq!(m.ppu_read(0x0000), 0x82);
+        // Rows 1-7 of tile $FD do not flip either.
+        for row in 1..8u16 {
+            m.ppu_fetch(0x0FD8 + row);
+            assert_eq!(m.ppu_read(0x0000), 0x82, "row {row}");
+        }
+    }
+
+    #[test]
+    fn latch_1_decodes_all_rows() {
+        let mut m = mmc2();
+        set_chr(&mut m, 1, 2, 3, 4);
+        for row in 0..8u16 {
+            m.ppu_fetch(0x1FD8 + row);
+            assert_eq!(m.ppu_read(0x1000), 0x83, "row {row}");
+            m.ppu_fetch(0x1FE8 + row);
+            assert_eq!(m.ppu_read(0x1000), 0x84, "row {row}");
+        }
+    }
+
+    #[test]
+    fn other_fetches_and_low_plane_do_not_flip() {
+        let mut m = mmc2();
+        set_chr(&mut m, 1, 2, 3, 4);
+        m.ppu_fetch(0x0FD8);
+        m.ppu_fetch(0x1FD8);
+        // Low plane of $FE ($xFE0-$xFE7), tile $FC, tile $FF, and
+        // nametable addresses are not triggers.
+        for addr in [
+            0x0FE0, 0x0FE7, 0x1FE0, 0x1FE7, 0x0FC8, 0x1FF8, 0x0FF8, 0x2FE8, 0x0000,
+        ] {
+            m.ppu_fetch(addr);
+        }
+        assert_eq!(m.ppu_read(0x0000), 0x81);
+        assert_eq!(m.ppu_read(0x1000), 0x83);
+    }
+
+    #[test]
+    fn read_at_trigger_address_uses_old_bank_and_peek_never_flips() {
+        let mut m = mmc2();
+        set_chr(&mut m, 1, 2, 3, 4);
+        // Latch 0 is $FE; the byte at $0FD8 itself comes from the FE bank
+        // because the PPU calls ppu_read before ppu_fetch.
+        assert_eq!(m.ppu_read(0x0FD8), 0x82);
+        assert_eq!(m.ppu_peek(0x0FD8), 0x82);
+        assert_eq!(m.ppu_read(0x0000), 0x82);
+        m.ppu_fetch(0x0FD8);
+        assert_eq!(m.ppu_peek(0x0000), 0x81);
+        assert_eq!(m.ppu_peek(0x0000), m.ppu_read(0x0000));
+    }
+
+    #[test]
+    fn chr_bank_wraps_to_image_size() {
+        let mut m = Mapper9::new(
+            tagged_rom(2, 0x2000),
+            tagged_rom(4, 0x1000),
+            Mirroring::Vertical,
+        );
+        m.cpu_write(0xC000, 6);
+        assert_eq!(m.ppu_read(0x0000), 2);
+        m.cpu_write(0xE000, 0x1F);
+        assert_eq!(m.ppu_read(0x1000), 3);
+    }
+
+    #[test]
+    fn mirroring_register() {
+        let mut m = mmc2();
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        m.cpu_write(0xF000, 1);
+        assert_eq!(m.mirroring(), Mirroring::Horizontal);
+        m.cpu_write(0xFFFF, 0xFE);
+        assert_eq!(m.mirroring(), Mirroring::Vertical);
+        let h = Mapper9::new(tagged_rom(2, 0x2000), vec![], Mirroring::Horizontal);
+        assert_eq!(h.mirroring(), Mirroring::Horizontal);
+    }
+
+    #[test]
+    fn prg_ram_is_readable_and_writable() {
+        let mut m = mmc2();
+        m.cpu_write(0x6000, 0x42);
+        m.cpu_write(0x7FFF, 0x24);
+        assert_eq!(m.cpu_read(0x6000), 0x42);
+        assert_eq!(m.cpu_peek(0x7FFF), 0x24);
+        assert_eq!(m.prg_ram().unwrap()[0], 0x42);
+    }
+
+    #[test]
+    fn save_state_round_trips_banks_and_latches() {
+        use crate::state::{Reader, Writer};
+        let mut m = mmc2();
+        m.cpu_write(0xA000, 5);
+        set_chr(&mut m, 1, 2, 3, 4);
+        m.ppu_fetch(0x0FD8); // latch 0 = FD, latch 1 stays FE
+        m.cpu_write(0xF000, 1);
+        m.cpu_write(0x6010, 0x5A);
+        let mut w = Writer::new();
+        m.save_state(&mut w);
+        let bytes = w.into_bytes();
+        let snapshot = |m: &mut Mapper9| {
+            (
+                m.cpu_read(0x8000),
+                m.ppu_read(0x0000),
+                m.ppu_read(0x1000),
+                m.mirroring(),
+            )
+        };
+        let before = snapshot(&mut m);
+        assert_eq!(before, (5, 0x81, 0x84, Mirroring::Horizontal));
+
+        m.cpu_write(0xA000, 2);
+        set_chr(&mut m, 9, 10, 11, 12);
+        m.ppu_fetch(0x0FE8);
+        m.ppu_fetch(0x1FD8);
+        m.cpu_write(0xF000, 0);
+        assert_ne!(snapshot(&mut m), before);
+
+        let mut r = Reader::new(&bytes);
+        m.load_state(&mut r).unwrap();
+        assert_eq!(r.remaining(), 0);
+        assert_eq!(snapshot(&mut m), before);
+        assert_eq!(m.cpu_read(0x6010), 0x5A);
+        let mut again = Writer::new();
+        m.save_state(&mut again);
+        assert_eq!(again.into_bytes(), bytes);
+    }
+}

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -7,12 +7,18 @@
 pub mod mapper;
 pub mod mapper0;
 pub mod mapper1;
+pub mod mapper10;
+pub mod mapper11;
 pub mod mapper2;
 pub mod mapper227;
 pub mod mapper3;
 pub mod mapper4;
 pub mod mapper5;
 pub mod mapper65;
+pub mod mapper66;
+pub mod mapper69;
+pub mod mapper7;
+pub mod mapper9;
 
 use std::fs::File;
 use std::io::{Error, ErrorKind, Read, Result};
@@ -159,7 +165,13 @@ impl Cartridge {
             3 => Box::new(mapper3::Mapper3::new(prg_rom, chr_rom, mirroring)),
             4 => Box::new(mapper4::Mapper4::new(prg_rom, chr_rom, mirroring)),
             5 => Box::new(mapper5::Mapper5::new(prg_rom, chr_rom, mirroring)),
+            7 => Box::new(mapper7::Mapper7::new(prg_rom, chr_rom, mirroring)),
+            9 => Box::new(mapper9::Mapper9::new(prg_rom, chr_rom, mirroring)),
+            10 => Box::new(mapper10::Mapper10::new(prg_rom, chr_rom, mirroring)),
+            11 => Box::new(mapper11::Mapper11::new(prg_rom, chr_rom, mirroring)),
             65 => Box::new(mapper65::Mapper65::new(prg_rom, chr_rom, mirroring)),
+            66 => Box::new(mapper66::Mapper66::new(prg_rom, chr_rom, mirroring)),
+            69 => Box::new(mapper69::Mapper69::new(prg_rom, chr_rom, mirroring)),
             227 => Box::new(mapper227::Mapper227::new(prg_rom, chr_rom, mirroring)),
             other => {
                 log::warn!(

--- a/src/ppu/mod.rs
+++ b/src/ppu/mod.rs
@@ -541,7 +541,13 @@ impl Ppu {
     fn read_vram(&mut self, addr: u16, mapper: &mut dyn Mapper) -> u8 {
         self.drive_addr_bus(addr, mapper);
         match addr {
-            0x0000..=0x1FFF => mapper.ppu_read(addr),
+            0x0000..=0x1FFF => {
+                // Read first, then report the completed fetch: the MMC2
+                // latch flips after the byte at $xFD8/$xFE8 is out.
+                let value = mapper.ppu_read(addr);
+                mapper.ppu_fetch(addr);
+                value
+            }
             0x2000..=0x2FFF => {
                 let index = self.mirror_nametable_addr(addr, mapper.mirroring());
                 self.nametable_ram[index as usize]
@@ -1371,6 +1377,35 @@ mod tests {
         mapper.cpu_write(0x8000, 1);
         assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x0000), 0x11);
         assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x1FFF), 0x11);
+    }
+
+    #[test]
+    fn pattern_reads_report_the_fetch_to_the_mapper_after_the_byte() {
+        // MMC2 with distinct 4 KB banks for the $FD and $FE latch states:
+        // a $2007 read of $0FE8 (tile $FE, high plane, row 0) returns the
+        // byte from the pre-flip bank and flips latch 0 for the next read,
+        // and a read of $0FD8 flips it back. This is the PPU-side proof
+        // that `read_vram` calls `ppu_fetch` after `ppu_read`.
+        let mut ppu = Ppu::new();
+        let mut chr = Vec::new();
+        for bank in 0u8..4 {
+            chr.extend(vec![0x20 | bank; 0x1000]);
+        }
+        let mut mapper =
+            crate::cartridge::mapper9::Mapper9::new(vec![0; 0x8000], chr, Mirroring::Vertical);
+        mapper.cpu_write(0xB000, 1); // latch 0 = $FD -> bank 1
+        mapper.cpu_write(0xC000, 2); // latch 0 = $FE -> bank 2 (power-on)
+
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x0000), 0x22);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x0FD8), 0x22);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x0000), 0x21);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x0FE8), 0x21);
+        assert_eq!(read_ppu_addr(&mut ppu, &mut mapper, 0x0000), 0x22);
+        // The background fetch path goes through the same read.
+        ppu.bg_next_tile_id = 0xFD;
+        ppu.v = 0;
+        ppu.fetch_pattern_high(&mut mapper); // $0FD8
+        assert_eq!(mapper.ppu_peek(0x0000), 0x21);
     }
 
     #[test]

--- a/src/system.rs
+++ b/src/system.rs
@@ -300,6 +300,10 @@ impl System {
         self.ppu_step();
         self.ppu_step();
         self.apu.step();
+        // Mapper CPU-cycle clock (FME-7 IRQ counter), before the IRQ sample.
+        if let Some(ref mut cart) = self.cartridge {
+            cart.mapper.cpu_clock();
+        }
         self.sample_irq_input();
 
         // Reload DMA: the output unit just emptied the sample buffer. The


### PR DESCRIPTION
## Summary

Six new mappers for wider library coverage, one file each under `src/cartridge/`, registered in `Cartridge::build_mapper`. Each implements `cpu_read`/`cpu_write`/`cpu_peek`, `ppu_read`/`ppu_write`/`ppu_peek`, `mirroring`, `prg_ram`/`prg_ram_mut` and `save_state`/`load_state` in the existing `mapper2.rs`/`mapper4.rs` shape.

| Mapper | Board | Notes |
|--------|-------|-------|
| 7 | AxROM | 32 KB PRG bank from bits 0-2, single-screen page from bit 4, CHR RAM |
| 9 | MMC2 (Punch-Out) | 8 KB PRG bank with the last three fixed, four 4 KB CHR registers picked by the tile $FD/$FE latches |
| 10 | MMC4 (Fire Emblem) | Same core as MMC2 with 16 KB PRG banking and whole-row latch 0 decoding |
| 11 | Color Dreams | PRG bank bits 0-1, CHR bank bits 4-7 |
| 66 | GxROM | PRG bank bits 4-5, CHR bank bits 0-1 |
| 69 | Sunsoft FME-7 | Command/parameter registers, eight 1 KB CHR banks, three 8 KB PRG banks plus the $6000 RAM/ROM slot with open bus, four mirroring modes, 16-bit IRQ counter per CPU cycle |

MMC2 and MMC4 share `Mmc2Core` in `mapper9.rs` (a `Kind` switch covers the two differences); `Mapper9` and `Mapper10` are newtypes that forward every trait method through a small macro, so `mapper10.rs` has no `impl Mapper` block of its own.

## Trait hooks

Two new `Mapper` methods with default no-ops:

- `ppu_fetch(addr)`: called by `Ppu::read_vram` right after `mapper.ppu_read` for every pattern-table access (background, sprite and $2007 reads). The byte at the trigger address comes from the pre-flip bank and the next fetch from the new one, per nesdev. MMC2 latch 0 decodes $0FD8/$0FE8 only, MMC4 decodes $0FD8-$0FDF/$0FE8-$0FEF; latch 1 decodes the whole row range on both.
- `cpu_clock()`: called once per CPU cycle from `System::tick`, after the APU step and before `sample_irq_input`, so an FME-7 counter wrap is visible to the same cycle's IRQ sample. This is a single `if let` statement and the only change to `src/system.rs`.

## Tests

- Per-mapper unit tests on `tagged_rom` images: power-on layout, every bank field including the bits that must not leak into it, wrap to image size, mirroring, the FME-7 $6000 slot modes and open bus, the FME-7 IRQ counter (exact cycle count, high byte, counter-enable and IRQ-enable independently, command $D acknowledge), and a save-state round trip per mapper (switch, save, switch, load, reads match).
- MMC2/MMC4 latch tests drive `ppu_fetch` directly for every trigger row and a set of non-triggers.
- `src/ppu/mod.rs`: `pattern_reads_report_the_fetch_to_the_mapper_after_the_byte` proves the hook is wired through $2007 and `fetch_pattern_high`.
- 208 lib tests pass; nestest, blargg and the MMC3 tests stay green.

## Fingerprint check

`cargo test --release --test game_frames -- --ignored --nocapture` before and after, with `roms/` symlinked. Ten of the eleven ROMs are hash-identical at every checkpoint, which is the proof that the two hooks are behavioural no-ops for existing boards (the only path that differs for those ROMs is the default trait method).

The one changed ROM is `SuperMarioBros.nes`. Its header says mapper 66 (64 KB PRG, 16 KB CHR), so it moves from the NROM fallback to `Mapper66`. Frame dumps at 240 frames from a `git archive main` build show garbage tiles from the wrong CHR bank; this branch shows the correct title screen. This is the mapper going live, not the hook.

## Gates

`cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all pass. Commit is GPG-signed. No version bump or CHANGELOG edits.

Docs: `docs/debugging/MAPPER_TRAIT_REFACTOR.md` gains the trait hooks, table rows, a section per mapper and updated how-to steps; `docs/debugging/SAVE_STATES.md` gains the MAPR rows.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxTxFRHaGyrzRe97K8Hdpb
