### PR TITLE
test(sweep): start commercial ROM checks from saved gameplay states

### DIFF
--- a/docs/testing/COMPATIBILITY_SWEEP.md
+++ b/docs/testing/COMPATIBILITY_SWEEP.md
@@ -1,22 +1,59 @@
 # Compatibility Sweep
 
-**Date:** 2026-09-05
-**Emulator version:** 0.8.0 (test ROM suite complete, 75 of 76 blargg suites)
-**Method:** `tests/game_sweep.rs`, frames viewed by a human (and by Claude
-via image reading) at frames 400, 900, 1500 and 2400.
+**Date:** 2026-09-05 (states flow, issue #41); first sweep 2026-09-05 at 0.8.0
+**Emulator version:** 0.11.0 (save states, issue #39)
+**Method:** `tests/sweep_states.rs` builds a save state inside gameplay for
+each ROM; `tests/game_sweep.rs` loads it and plays with a per-game script,
+writing frames at 400, 900, 1500 and 2400 that a human (and Claude, via
+image reading) looks at.
 
 ## Why
 
 The test ROM harness proves CPU, PPU, APU and MMC3 behaviour to the cycle,
 but it only exercises what test ROMs cover. This sweep drives every ROM in
-`roms/` into gameplay with scripted input and looks at the frames. It is
-the regression check for behaviour the harness cannot see.
+`roms/` into gameplay and looks at the frames. It is the regression check
+for behaviour the harness cannot see.
+
+The first version drove every game with one fixed script (Start four
+times, hold Right, tap A) from power-on. That stalled on any game with a
+menu path: SMB3 never left the map, Zelda sat on the name registration
+screen, TMNT on the area 1 information screen. With save states the menu
+path is scripted once per game, saved, and the sweep starts inside the
+level.
 
 ## Running it
 
+Two steps. The first only needs repeating when a recipe changes or the
+state format moves (see "State files are build-bound" below).
+
 ```bash
+# 1. Build roms/<stem>.sweep.state for every game (about 10 s in release)
+cargo test --release --test sweep_states -- --ignored --nocapture
+
+# 2. The sweep: loads each state, plays, writes PPM frames
 SWEEP_OUT=/tmp/sweep cargo test --release --test game_sweep -- --ignored --nocapture
 ```
+
+`roms/` and everything in it (ROMs, `.sav`, `.sweep.state`) is gitignored.
+A missing ROM is skipped with a message. The sweep prints the mode per
+game:
+
+```text
+SuperMarioBros3.nes: mapper 4
+SuperMarioBros3.nes: mode state (SuperMarioBros3.sweep.state), script Hopper
+SuperMarioBros.nes: mapper 66
+SuperMarioBros.nes: mode menu script
+```
+
+Tuning knobs:
+
+- `SWEEP_ONLY=<substring>` (game_sweep): only ROMs whose file name
+  contains it.
+- `SWEEP_TRACE=<dir>` and `SWEEP_TRACE_EVERY=<n>` (sweep_states): a PPM
+  every n frames (default 50) along the recipe, which is how the recipes
+  were tuned. `SWEEP_OUT=<dir>` writes the first frame after each state
+  loads as `<stem>.state.ppm`.
+- One recipe: `cargo test --release --test sweep_states -- --ignored zelda`.
 
 Frames are binary PPM, 256x240. To convert to PNG with no dependencies:
 
@@ -35,29 +72,137 @@ with open(sys.argv[2], 'wb') as f:
     f.write(chunk(b'IEND', b''))
 ```
 
-The script is deliberately simple: Start at frames 150, 300, 450 and 600,
-then hold Right and tap A every 40 frames. Games that need Select, a
-specific menu path, or Start to leave an info screen will stall at that
-screen; that is a limit of the script, not a bug, and is noted per game.
+Forty frames are easier to judge as a contact sheet: concatenate the
+PPMs row by row into one image and write it with the same script, with
+the IHDR width and height scaled to `W * cols` by `H * rows`.
 
-## Results at 0.8.0
+## How the states are built
 
-| ROM | Mapper | Frame 1500 / 2400 | Verdict |
+`tests/sweep_states.rs` has one recipe per game: a list of timed button
+events (`tap` holds a button 8 frames, `hold` spans a range, `mash`
+repeats a tap) and a save frame. At the save frame every button is
+released, four idle frames run so no held input is baked into the image
+(the `INPT` section stores the controller and a held Right would steer
+the sweep before its script starts), and `System::save_state` writes
+`roms/<stem>.sweep.state`.
+
+Each state is then verified in a fresh `System`: load the ROM, load the
+image, run 60 frames on it and on the recipe machine, and assert the two
+frame buffers and the two `save_state` images are identical. Any recipe
+whose state failed this would be reported as such; all ten pass.
+
+| ROM | Recipe (frame: input) | Save | Where it lands |
 |---|---|---|---|
-| mario.nes | 0 | World 1-1, scrolling, Goomba and pipe drawn, status bar stable | OK |
-| Contra.nes | 2 | Stage 1 in play, both players, mountains and water correct | OK |
-| SuperMarioBros2.nes | 4 | World 1-1 in play, Mario climbing the hill | OK |
-| SuperMarioBros3.nes | 4 | World 1 map with status bar (MMC3 IRQ split) | OK, script does not enter a level |
-| Teenage Mutant Ninja Turtles (USA).nes | 1 | Area 1 information screen, all text and portraits correct | OK, screen needs Start to continue |
-| zelda.nes | 1 | Name registration, script types letters | OK, script cannot leave the screen |
-| final_fantasy.nes | 1 | Name entry at 1500, overworld by 2400 with the party sprite | OK |
-| river_city_ransom.nes | 4 | Cross Town High, Alex fighting two gang members | OK |
-| Tetris.nes | 1 (archaic header) | A-Type level select and high score table | OK |
-| SuperMarioBros.nes | reads as 66 | Not exercised; dirty header, use mario.nes | Skip |
-| 1200-in-1.nes | 227 | Menu draws; script's first Start launches Bomberman, stage 1 board with enemies at 900 (paused by the later Start taps) | OK since issue 25; menu navigates with Select (page) and Down/Up (line), not Right |
+| mario.nes | 150 Start; 200-400 hold Right | 404 | World 1-1, Mario past the first Goomba |
+| SuperMarioBros2.nes | 150 Start; 300 Start; 450 A (Mario); 700-1000 hold Right | 1004 | World 1-1, Mario on the grass after the intro drop |
+| SuperMarioBros3.nes | 150 Start; 300 Start; 600-640 hold Right; 700 A; 760 Up; 820 Right; 880 A | 1104 | World 1-1, level start with the status bar |
+| zelda.nes | 150 Start; 300 Start (REGISTER); 400 A (types A); 460, 500, 540 Select (heart to REGISTER); 600 Start; 700 Start | 1104 | Overworld start screen, Link standing |
+| Contra.nes | 300 Start; 600-900 hold Right | 904 | Stage 1, first sniper box |
+| Teenage Mutant Ninja Turtles (USA).nes | 150 Start; 400 Start; 950 Start; 1250 Start | 1504 | Area 1 overworld, Leonardo beside the first manhole |
+| final_fantasy.nes | 150, 300, 450, 600 Start; A every 40 from 720 | 2404 | Overworld outside Coneria, party named AAAA |
+| river_city_ransom.nes | 150 Start; 300 Start (1P, Alex); 500 Start (speed and skill); 700-1100 hold Right | 1104 | Cross Town High, first gang members |
+| Tetris.nes | 300, 450, 600, 750 Start | 904 | A-Type, level 0, first piece falling |
+| 1200-in-1.nes | 150 Start (menu, Bomberman); 400 Start (Bomberman title) | 704 | Bomberman stage 1 |
+| SuperMarioBros.nes | none | | Dirty header reads as mapper 66; the sweep's menu script draws garbage. Use mario.nes. |
+
+Recipe notes, found by viewing `SWEEP_TRACE` frames:
+
+- **SMB3.** Two Start presses reach the map (a third lands on the map and
+  breaks movement). The WORLD 1 panel stays up until about frame 550, so
+  Right must be held after that; then A, Up, Right, A. The first A on the
+  level panel is ignored and the second enters. Mario's map X is at zero
+  page $79 (START is $20, level 1 is $40).
+- **Zelda.** With no save files the select screen's heart starts on
+  REGISTER YOUR NAME, so the second Start opens registration directly. On
+  the register screen A types the highlighted letter into file 1, and
+  Select cycles the heart file 1, 2, 3, REGISTER, file 1: it skips END,
+  so END is never used. Start with the heart on REGISTER returns to the
+  select screen with the file named and highlighted, and Start there
+  begins the game. Link is on the overworld by frame 820. Note that
+  `roms/zelda.sav` exists in the main checkout; the sweep never calls
+  `load_battery`, so registration always starts from an empty file list.
+- **TMNT.** The copyright screen ignores Start. Start on the title, then
+  the sewer intro and the area 1 information screen play by themselves.
+  The information screen types two pages of text; Start only counts once
+  a page has finished (about frames 800 and 1150).
+- **Contra.** The title finishes scrolling in at about frame 250; Start
+  before that is ignored.
+- **River City Ransom.** After 1P PLAY there is a message speed and skill
+  level screen that needs its own Start. Holding Right on it moves the
+  cursor to ADVANCED, which is what the state has.
+- **Tetris.** The legal screen ignores Start until about frame 250; then
+  title, game type (A-Type) and level select each take one Start.
+- **1200-in-1.** One Start launches the highlighted entry (Bomberman), one
+  more on its title starts stage 1; any later Start pauses it, so no play
+  script taps Start.
+- **Final Fantasy.** The old menu script already reached the overworld by
+  frame 2400 (the A taps name every character AAAA), so it is the recipe.
+
+## How the sweep plays
+
+`game_sweep.rs` keeps the four checkpoints and PPM names. In state mode
+the script starts 30 frames after the load and never taps Start (it
+pauses most games). The table maps ROM stem to script; an unknown stem
+plays as a platformer.
+
+| Script | Input | Games |
+|---|---|---|
+| Platformer | hold Right, hold A 24 frames every 40 (a full jump) | mario, SMB2, Contra, Zelda, 1200-in-1 |
+| Hopper | hold Right, tap A 6 frames every 40 (a short hop) | SMB3 |
+| Fighter | hold Right, tap A and B alternately every 30 | River City Ransom |
+| Tetris | tap Right every 60, tap A (rotate) every 45 | Tetris |
+| Walker | hold Right only (A opens the menu on an RPG overworld) | Final Fantasy |
+| Sewer | hold Left 26 frames onto the manhole; from frame 230 hold Down off the ladder; from 350 hold Right and jump | TMNT |
+
+The Hopper script exists because every longer jump tried in SMB3 1-1
+(10, 14 or 24 frames, every 40, 48 or 64 frames, with or without B held
+to run) put Mario on the Goomba or the piranha plant before frame 900
+and the rest of the run was the map. The short hop keeps him alive at
+the first pipe for all 2400 frames, which exercises the level renderer
+(scrolling, sprites, MMC3 status bar split) more than the map does.
+
+## Results at 0.11.0
+
+All frames from state mode; SuperMarioBros.nes ran the menu script.
+
+| ROM | Mapper | Frames 400 / 900 / 1500 / 2400 | Verdict |
+|---|---|---|---|
+| mario.nes | 0 | 1-1 past the first pipe; between the pipes; jumping the brick row at score 200; dies and the WORLD 1-1 card with 1 life at 2400 | OK, plays through the level |
+| SuperMarioBros2.nes | 4 | 1-1 grass hill, Mario walking Right into the wall and jumping; door on the right in every frame | OK, stalls at the first wall but in play |
+| SuperMarioBros3.nes | 4 | 1-1 at the first pipe in all four frames, timer counting down (293, 276, 251, 233), status bar split stable | OK, in the level for the whole run (see Hopper) |
+| zelda.nes | 1 | Overworld start screen, Link walking Right; Octoroks and rocks; hearts drop 3, 3, 1.5; CONTINUE / SAVE / RETRY by 2400 | OK, plays until Link dies |
+| Contra.nes | 2 | Stage 1 sniper box; bridge explosion; second sniper box with enemies; jungle further right | OK |
+| Teenage Mutant Ninja Turtles (USA).nes | 1 | First sewer level, Leonardo on the ladder then fighting Foot soldiers on the lower floor; caught by 2400, LEONARDO GOT CAUGHT, WHO FIGHTS NEXT with Raphael | OK, plays into the sewer |
+| final_fantasy.nes | 1 | Overworld outside Coneria, party walking Right to the coast and stopping at the water | OK |
+| river_city_ransom.nes | 4 | Cross Town High; two screens further, Alex fighting Generic Dudes with a dropped weapon; the Trash Pick-Up alley | OK, scrolls through several screens |
+| Tetris.nes | 1 (archaic header) | A-Type in play, pieces landing on the right side, statistics counting | OK |
+| 1200-in-1.nes | 227 | Bomberman stage 1, bomb placed, balloons; killed twice; GAME OVER at 2400 | OK |
+| SuperMarioBros.nes | reads as 66 | Title and garbage tiles; dirty header | Skip, use mario.nes |
+
+No rendering defect was seen in any supported game across 2400 frames of
+play from the states.
 
 ## Findings
 
+- **State files are build-bound.** A state is refused for another ROM
+  (CRC-32 in the header) and fails with a layout error if a section's
+  save/load order changed since it was written, which can happen without
+  a format version bump. `game_sweep.rs` prints the error, rebuilds the
+  machine (a layout error is reported after earlier sections were
+  applied) and falls back to the menu script, so a stale state never
+  produces a half-loaded run. Rerun `sweep_states` after any change to
+  `save_state`/`load_state` or a mapper's snapshot.
+- **First frame after a load differs on row 0 only.** For SMB2, Zelda,
+  TMNT and Final Fantasy (and River City Ransom on some runs) the
+  verification prints that the first frame after the load differs from
+  the recipe machine on exactly one row, row 0, and it is not flat in the
+  fresh machine. The frame buffer is not in the image, and `run_frame`
+  evidently returns after scanline 0 has already been partly drawn, so
+  the fresh machine draws the remainder of that row over black. From the
+  second frame the pictures and the complete state images are identical
+  for all ten games. Cosmetic, and self-healing on the next frame, but
+  it is the reason the verification compares frame 60 rather than frame
+  1 (documented in `tests/sweep_states.rs`).
 - **SMB3 left border and right-edge seam (0.8.4).** In levels the game
   clears the PPU mask's left-column bits, so the leftmost 8 pixels are
   always blank, and it runs horizontally scrolling levels with horizontal
@@ -69,12 +214,6 @@ screen; that is a limit of the script, not a bug, and is noted per game.
   at all 512 horizontal scroll values showed every column correct, so the
   PPU is not at fault. The binary now crops 8 pixels on all four edges by
   default.
-- **Reaching an SMB3 level from a script.** Two Start presses reach the
-  map (a third lands on the map and breaks movement). Then hold Right 40
-  frames, wait, press A, press Up, press Right again, press A: the first A
-  on the level panel is ignored and the second enters. Mario's map X is at
-  zero page $79 (START is $20, level 1 is $40).
-
 - **Final Fantasy overworld top band (0.8.3).** Walking vertically showed a
   one-frame band of wrong colours in the top eight lines. Tracing the PPU
   registers showed the emulation is exact: the vertical scroll sits at
@@ -85,17 +224,29 @@ screen; that is a limit of the script, not a bug, and is noted per game.
   and bottom by default (`--full-frame` disables it). The detector that
   found it, comparing the top 16 rows against the rest of the frame for a
   disagreeing scroll shift, is worth keeping in mind for similar reports.
-
 - **Mapper 227 (1200-in-1 multicart)** was unimplemented at 0.8.0: the
   loader fell back to NROM and every frame was the solid backdrop. Issue 25
   added `src/cartridge/mapper227.rs` (see
-  docs/debugging/MAPPER_TRAIT_REFACTOR.md). The menu now draws with no
-  input, Select pages it, Down/Up move the cursor, and Start launches the
-  highlighted game; Bomberman and Galaxian both reach their title or first
-  stage. Right is not a menu key on this cart, so the sweep script simply
-  starts the default entry.
-- No rendering defect was seen in any supported game across 2400 frames of
-  scripted play.
+  docs/debugging/MAPPER_TRAIT_REFACTOR.md). The menu draws with no input,
+  Select pages it, Down/Up move the cursor, and Start launches the
+  highlighted game. Right is not a menu key on this cart, so the recipe
+  simply starts the default entry.
+
+## Results at 0.8.0 (menu script, for comparison)
+
+| ROM | Frame 1500 / 2400 | Verdict |
+|---|---|---|
+| mario.nes | World 1-1, scrolling, Goomba and pipe drawn, status bar stable | OK |
+| Contra.nes | Stage 1 in play, both players, mountains and water correct | OK |
+| SuperMarioBros2.nes | World 1-1 in play, Mario climbing the hill | OK |
+| SuperMarioBros3.nes | World 1 map with status bar (MMC3 IRQ split) | OK, script does not enter a level |
+| Teenage Mutant Ninja Turtles (USA).nes | Area 1 information screen, all text and portraits correct | OK, screen needs Start to continue |
+| zelda.nes | Name registration, script types letters | OK, script cannot leave the screen |
+| final_fantasy.nes | Name entry at 1500, overworld by 2400 with the party sprite | OK |
+| river_city_ransom.nes | Cross Town High, Alex fighting two gang members | OK |
+| Tetris.nes | A-Type level select and high score table | OK |
+| SuperMarioBros.nes | Not exercised; dirty header, use mario.nes | Skip |
+| 1200-in-1.nes | Menu draws; first Start launches Bomberman, stage 1 board at 900 (paused by the later Start taps) | OK since issue 25 |
 
 ## What this does not cover
 
@@ -103,5 +254,6 @@ screen; that is a limit of the script, not a bug, and is noted per game.
   counters and sweep units all changed in 0.7.0 and 0.8.0 and need a listen
   in the real binary.
 - Deeper gameplay: later levels, bank switches that only happen on later
-  stages, and save RAM.
+  stages, and save RAM. A second state per game, saved further in, would
+  extend the sweep the same way.
 - Timing-sensitive raster effects beyond status bars.

--- a/tests/game_sweep.rs
+++ b/tests/game_sweep.rs
@@ -1,15 +1,29 @@
 //! Scripted gameplay sweep over the commercial ROMs in `roms/`.
 //!
 //! `tests/game_frames.rs` hashes frames near the title screen. This test
-//! drives each game further: Start is tapped four times to get through
-//! title and menu screens, then Right is held and A tapped every 40 frames
-//! so side-scrollers and fighters actually play. Frames are written as
-//! binary PPM (viewable directly, or convert to PNG with the stdlib-only
-//! script in docs/testing/COMPATIBILITY_SWEEP.md) at four checkpoints.
+//! drives each game further and writes frames as binary PPM (viewable
+//! directly, or convert to PNG with the stdlib-only script in
+//! docs/testing/COMPATIBILITY_SWEEP.md) at four checkpoints.
+//!
+//! Two modes, chosen per ROM and printed:
+//!
+//! - **state**: `roms/<stem>.sweep.state` exists (built by
+//!   `tests/sweep_states.rs`) and loads. The game starts inside gameplay
+//!   and a per-game input script (`scripts`) plays it: platformers hold
+//!   Right and tap A, the fighter alternates A and B, Tetris nudges and
+//!   rotates, the RPG just walks. Frame numbers count from the load.
+//! - **menu**: no state, or it failed to load (a state is bound to the
+//!   build that wrote it; a layout error means rebuild it). The original
+//!   script runs from power-on: Start at frames 150, 300, 450 and 600,
+//!   then hold Right and tap A every 40 frames. Games that need a menu
+//!   path stall at that screen; that is a limit of the script, not a bug.
 //!
 //! ```text
 //! SWEEP_OUT=/tmp/sweep cargo test --release --test game_sweep -- --ignored --nocapture
 //! ```
+//!
+//! `SWEEP_ONLY=<substring>` restricts the run to ROMs whose file name
+//! contains it, for tuning one game's script.
 //!
 //! Ignored because `roms/` is not part of the repository and the output
 //! needs a human to look at it. Results and the per-game verdicts are in
@@ -18,16 +32,168 @@
 use nes_emu::cartridge::Cartridge;
 use nes_emu::input::ControllerButton;
 use nes_emu::system::System;
+use std::collections::HashMap;
 use std::path::Path;
 
 const CHECKPOINTS: [usize; 4] = [400, 900, 1500, 2400];
 const START_TAPS: [usize; 4] = [150, 300, 450, 600];
 const PLAY_FROM: usize = 700;
 
+/// Frames of settling after a state load before the script starts.
+const STATE_PLAY_FROM: usize = 30;
+
+/// How a game is played once it is in gameplay.
+#[derive(Clone, Copy, Debug)]
+enum Script {
+    /// Hold Right, hold A for a full jump every 40 frames (jump, bomb,
+    /// sword).
+    Platformer,
+    /// Hold Right, tap A every 40 frames: a short hop. Every longer jump
+    /// tried in SMB3 1-1 lands Mario on the Goomba or the piranha plant
+    /// by frame 900; the hop keeps him alive (stalled at the first pipe)
+    /// for the whole run, which exercises the level renderer more than
+    /// the map does.
+    Hopper,
+    /// Hold Left for 26 frames: walks onto the manhole to the left of
+    /// the TMNT area 1 start, which drops into the first sewer on a
+    /// ladder; from frame 200 hold Down to climb off it, then from 320
+    /// hold Right and jump like a platformer.
+    Sewer,
+    /// Hold Right, alternate A and B taps every 30 frames (punch, kick).
+    Fighter,
+    /// Tap Right every 60 frames and A every 45 to rotate; pieces drift
+    /// right and stack instead of piling in one column.
+    Tetris,
+    /// Hold Right only: A would open the menu on an RPG overworld.
+    Walker,
+}
+
+/// ROM stem to play script. A stem not listed plays as a platformer.
+fn scripts() -> HashMap<&'static str, Script> {
+    HashMap::from([
+        ("mario", Script::Platformer),
+        ("SuperMarioBros2", Script::Platformer),
+        ("SuperMarioBros3", Script::Hopper),
+        ("Contra", Script::Platformer),
+        ("zelda", Script::Platformer),
+        ("Teenage Mutant Ninja Turtles (USA)", Script::Sewer),
+        ("river_city_ransom", Script::Fighter),
+        ("Tetris", Script::Tetris),
+        ("final_fantasy", Script::Walker),
+        ("1200-in-1", Script::Platformer),
+    ])
+}
+
 fn write_ppm(path: &Path, rgb: &[u8]) {
     let mut out = b"P6\n256 240\n255\n".to_vec();
     out.extend_from_slice(rgb);
     std::fs::write(path, out).unwrap();
+}
+
+/// Frames a tapped button stays down; enough for every game's debounce.
+const TAP: usize = 6;
+
+/// Frames a jump button stays down: a full-height jump in the Mario
+/// games needs A held for most of the rise.
+const JUMP: usize = 24;
+
+/// Press `b` for `hold` frames every `every` frames from `from`, offset
+/// by `phase`.
+fn tap(
+    sys: &mut System,
+    f: usize,
+    from: usize,
+    every: usize,
+    phase: usize,
+    hold: usize,
+    b: ControllerButton,
+) {
+    if f < from {
+        return;
+    }
+    let t = (f - from) % every;
+    if t == phase {
+        sys.controller1.press(b);
+    } else if t == phase + hold {
+        sys.controller1.release(b);
+    }
+}
+
+/// The original power-on script: Starts through the menus, then play.
+fn menu_script(sys: &mut System, f: usize) {
+    for s in START_TAPS {
+        if f == s {
+            sys.controller1.press(ControllerButton::START);
+        }
+        if f == s + 8 {
+            sys.controller1.release(ControllerButton::START);
+        }
+    }
+    if f == PLAY_FROM {
+        sys.controller1.press(ControllerButton::RIGHT);
+    }
+    tap(sys, f, PLAY_FROM, 40, 0, TAP, ControllerButton::A);
+}
+
+/// Play from a loaded state. Never taps Start: it pauses most games.
+fn play_script(sys: &mut System, f: usize, script: Script) {
+    let from = STATE_PLAY_FROM;
+    match script {
+        Script::Platformer => {
+            if f == from {
+                sys.controller1.press(ControllerButton::RIGHT);
+            }
+            tap(sys, f, from, 40, 0, JUMP, ControllerButton::A);
+        }
+        Script::Hopper => {
+            if f == from {
+                sys.controller1.press(ControllerButton::RIGHT);
+            }
+            tap(sys, f, from, 40, 0, TAP, ControllerButton::A);
+        }
+        Script::Sewer => {
+            if f == from {
+                sys.controller1.press(ControllerButton::LEFT);
+            }
+            if f == from + 26 {
+                sys.controller1.release(ControllerButton::LEFT);
+            }
+            if f == from + 200 {
+                sys.controller1.press(ControllerButton::DOWN);
+            }
+            if f == from + 320 {
+                sys.controller1.release(ControllerButton::DOWN);
+                sys.controller1.press(ControllerButton::RIGHT);
+            }
+            tap(sys, f, from + 320, 40, 0, JUMP, ControllerButton::A);
+        }
+        Script::Fighter => {
+            if f == from {
+                sys.controller1.press(ControllerButton::RIGHT);
+            }
+            tap(sys, f, from, 60, 0, TAP, ControllerButton::A);
+            tap(sys, f, from, 60, 30, TAP, ControllerButton::B);
+        }
+        Script::Tetris => {
+            tap(sys, f, from, 60, 0, TAP, ControllerButton::RIGHT);
+            tap(sys, f, from, 45, 10, TAP, ControllerButton::A);
+        }
+        Script::Walker => {
+            if f == from {
+                sys.controller1.press(ControllerButton::RIGHT);
+            }
+        }
+    }
+}
+
+/// Load the ROM into a new machine; returns the mapper number too.
+fn load(rom: &Path) -> Result<(System, u8), String> {
+    let bytes = std::fs::read(rom).map_err(|e| e.to_string())?;
+    let cart = Cartridge::load_from_bytes(&bytes).map_err(|e| e.to_string())?;
+    let mapper = cart.mapper_id;
+    let mut sys = System::new();
+    sys.load_cartridge(cart);
+    Ok((sys, mapper))
 }
 
 #[test]
@@ -54,37 +220,59 @@ fn sweep_commercial_roms() {
         }
     };
     roms.sort();
+    // SWEEP_ONLY=<substring> restricts the run to matching file names.
+    if let Ok(only) = std::env::var("SWEEP_ONLY") {
+        roms.retain(|p| p.file_name().unwrap().to_string_lossy().contains(&only));
+    }
+    let scripts = scripts();
 
     for rom in roms {
         let name = rom.file_name().unwrap().to_string_lossy().into_owned();
-        let cart = match Cartridge::load_from_bytes(&std::fs::read(&rom).unwrap()) {
-            Ok(c) => c,
+        let stem = rom.file_stem().unwrap().to_string_lossy().into_owned();
+        let (mut sys, mapper) = match load(&rom) {
+            Ok(s) => s,
             Err(e) => {
                 println!("{name}: load failed: {e}");
                 continue;
             }
         };
-        println!("{name}: mapper {}", cart.mapper_id);
-        let mut sys = System::new();
-        sys.load_cartridge(cart);
+        println!("{name}: mapper {mapper}");
+        // State mode when the image exists and loads; on any error the
+        // machine is rebuilt (a layout error can leave it half loaded)
+        // and the menu script runs from power-on.
+        let state_path = rom.with_extension("sweep.state");
+        let mut script = None;
+        if let Ok(image) = std::fs::read(&state_path) {
+            match sys.load_state(&image) {
+                Ok(()) => {
+                    let s = scripts
+                        .get(stem.as_str())
+                        .copied()
+                        .unwrap_or(Script::Platformer);
+                    println!(
+                        "{name}: mode state ({}), script {s:?}",
+                        state_path.file_name().unwrap().to_string_lossy()
+                    );
+                    script = Some(s);
+                }
+                Err(e) => {
+                    println!(
+                        "{name}: state {} refused ({e}); rebuild it with tests/sweep_states.rs",
+                        state_path.file_name().unwrap().to_string_lossy()
+                    );
+                    sys = load(&rom).unwrap().0;
+                }
+            }
+        }
+        if script.is_none() {
+            println!("{name}: mode menu script");
+        }
+
         let last = *CHECKPOINTS.last().unwrap();
         for f in 0..=last {
-            for s in START_TAPS {
-                if f == s {
-                    sys.controller1.press(ControllerButton::START);
-                }
-                if f == s + 8 {
-                    sys.controller1.release(ControllerButton::START);
-                }
-            }
-            if f == PLAY_FROM {
-                sys.controller1.press(ControllerButton::RIGHT);
-            }
-            if f >= PLAY_FROM && f % 40 == 0 {
-                sys.controller1.press(ControllerButton::A);
-            }
-            if f >= PLAY_FROM && f % 40 == 6 {
-                sys.controller1.release(ControllerButton::A);
+            match script {
+                Some(s) => play_script(&mut sys, f, s),
+                None => menu_script(&mut sys, f),
             }
             sys.run_frame();
             if CHECKPOINTS.contains(&f) {

--- a/tests/sweep_states.rs
+++ b/tests/sweep_states.rs
@@ -7,8 +7,11 @@
 //! released, a few idle frames run so no held input is baked into the
 //! image, and `System::save_state` writes `roms/<stem>.sweep.state`.
 //! The state is then verified: a fresh `System` loads the ROM and the
-//! image, and the first frame it draws must equal the frame the recipe
-//! run draws next.
+//! image, both machines run 60 frames, and their frame buffers and
+//! complete state images must be identical. (The first frame alone can
+//! differ on row 0: the frame buffer is not in the image and `run_frame`
+//! returns after scanline 0 has partly been drawn; that is printed as a
+//! note.)
 //!
 //! ```text
 //! # all games
@@ -206,7 +209,20 @@ fn build(recipe: Recipe) -> Option<PathBuf> {
     sys.run_frame();
     fresh.run_frame();
     if fnv(sys.get_frame_buffer()) != fnv(fresh.get_frame_buffer()) {
-        println!("{stem}: note: first frame after load differs (rendering off at the save point?)");
+        let (a, b) = (sys.get_frame_buffer(), fresh.get_frame_buffer());
+        let rows: Vec<usize> = (0..240)
+            .filter(|y| a[y * 768..(y + 1) * 768] != b[y * 768..(y + 1) * 768])
+            .collect();
+        let blank = rows
+            .iter()
+            .filter(|&&y| b[y * 768..(y + 1) * 768].iter().all(|&p| p == b[y * 768]))
+            .count();
+        println!(
+            "{stem}: note: first frame after load differs on {} rows ({}..={}), {blank} of them flat in the fresh machine",
+            rows.len(),
+            rows.first().unwrap(),
+            rows.last().unwrap()
+        );
     }
     for _ in 1..VERIFY {
         sys.run_frame();

--- a/tests/sweep_states.rs
+++ b/tests/sweep_states.rs
@@ -1,0 +1,385 @@
+//! Build the gameplay save states that `tests/game_sweep.rs` starts from
+//! (issue #41, docs/testing/COMPATIBILITY_SWEEP.md).
+//!
+//! Each game has a scripted path from power-on to the point where the
+//! player is in control (a level, the overworld, the first fight), tuned
+//! by looking at the frames. At the end of the path every button is
+//! released, a few idle frames run so no held input is baked into the
+//! image, and `System::save_state` writes `roms/<stem>.sweep.state`.
+//! The state is then verified: a fresh `System` loads the ROM and the
+//! image, and the first frame it draws must equal the frame the recipe
+//! run draws next.
+//!
+//! ```text
+//! # all games
+//! cargo test --release --test sweep_states -- --ignored --nocapture
+//! # one game, with a frame every 50 frames along the way for tuning
+//! SWEEP_TRACE=/tmp/trace cargo test --release --test sweep_states -- --ignored --nocapture zelda
+//! ```
+//!
+//! `SWEEP_OUT=<dir>` writes the verification frame of each state as a
+//! PPM (`<stem>.state.ppm`). `SWEEP_TRACE=<dir>` writes a PPM every
+//! `SWEEP_TRACE_EVERY` (default 50) frames during the recipe. Convert
+//! with the stdlib-only script in docs/testing/COMPATIBILITY_SWEEP.md.
+//!
+//! Ignored because `roms/` is not part of the repository. A missing ROM
+//! is reported and skipped, not a failure. State files are build-bound
+//! (the layout of a section can change without a version bump); rerun
+//! this test after any change to the save/load code.
+
+use nes_emu::cartridge::Cartridge;
+use nes_emu::input::ControllerButton;
+use nes_emu::system::System;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hasher;
+use std::path::{Path, PathBuf};
+
+const A: ControllerButton = ControllerButton::A;
+const B: ControllerButton = ControllerButton::B;
+const START: ControllerButton = ControllerButton::START;
+const SELECT: ControllerButton = ControllerButton::SELECT;
+const UP: ControllerButton = ControllerButton::UP;
+const DOWN: ControllerButton = ControllerButton::DOWN;
+const LEFT: ControllerButton = ControllerButton::LEFT;
+const RIGHT: ControllerButton = ControllerButton::RIGHT;
+
+/// Frames a tapped button stays down. Most games poll once per frame and
+/// debounce on the edge, so anything from 2 up works; 8 matches the
+/// menu script in `game_sweep.rs`.
+const TAP: usize = 8;
+
+/// Idle frames run after the last input, with everything released,
+/// before the image is taken.
+const SETTLE: usize = 4;
+
+/// Frames run after the load before the verification compares the two
+/// machines.
+const VERIFY: usize = 60;
+
+#[derive(Clone, Copy)]
+enum Ev {
+    Press(ControllerButton),
+    Release(ControllerButton),
+}
+
+/// A timed input script ending at `save_at`.
+struct Recipe {
+    rom: &'static str,
+    events: Vec<(usize, Ev)>,
+    save_at: usize,
+}
+
+impl Recipe {
+    fn new(rom: &'static str) -> Self {
+        Recipe {
+            rom,
+            events: Vec::new(),
+            save_at: 0,
+        }
+    }
+
+    /// Press `b` at `frame` and release it `TAP` frames later.
+    fn tap(mut self, frame: usize, b: ControllerButton) -> Self {
+        self.events.push((frame, Ev::Press(b)));
+        self.events.push((frame + TAP, Ev::Release(b)));
+        self
+    }
+
+    /// Hold `b` from `from` up to (not including) `to`.
+    fn hold(mut self, from: usize, to: usize, b: ControllerButton) -> Self {
+        self.events.push((from, Ev::Press(b)));
+        self.events.push((to, Ev::Release(b)));
+        self
+    }
+
+    /// Tap `b` every `every` frames in `[from, to)`.
+    fn mash(mut self, from: usize, to: usize, every: usize, b: ControllerButton) -> Self {
+        let mut f = from;
+        while f < to {
+            self = self.tap(f, b);
+            f += every;
+        }
+        self
+    }
+
+    fn save_at(mut self, frame: usize) -> Self {
+        self.save_at = frame;
+        self
+    }
+}
+
+fn fnv(buf: &[u8]) -> u64 {
+    let mut h = DefaultHasher::new();
+    h.write(buf);
+    h.finish()
+}
+
+fn write_ppm(path: &Path, rgb: &[u8]) {
+    let mut out = b"P6\n256 240\n255\n".to_vec();
+    out.extend_from_slice(rgb);
+    std::fs::write(path, out).unwrap();
+}
+
+fn roms_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("roms")
+}
+
+fn env_dir(var: &str) -> Option<PathBuf> {
+    let dir = PathBuf::from(std::env::var(var).ok()?);
+    std::fs::create_dir_all(&dir).unwrap();
+    Some(dir)
+}
+
+fn load(rom: &Path) -> Option<System> {
+    let bytes = match std::fs::read(rom) {
+        Ok(b) => b,
+        Err(e) => {
+            println!("{}: not available ({e}); skipped", rom.display());
+            return None;
+        }
+    };
+    let cart = match Cartridge::load_from_bytes(&bytes) {
+        Ok(c) => c,
+        Err(e) => {
+            println!("{}: load failed: {e}; skipped", rom.display());
+            return None;
+        }
+    };
+    let mut sys = System::new();
+    sys.load_cartridge(cart);
+    Some(sys)
+}
+
+/// Run the recipe, save the state next to the ROM, verify it in a fresh
+/// machine. Returns the state path, or `None` when the ROM is missing.
+fn build(recipe: Recipe) -> Option<PathBuf> {
+    let rom = roms_dir().join(recipe.rom);
+    let stem = rom.file_stem().unwrap().to_string_lossy().into_owned();
+    let mut sys = load(&rom)?;
+    let trace = env_dir("SWEEP_TRACE");
+    let every: usize = std::env::var("SWEEP_TRACE_EVERY")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+
+    for f in 0..=recipe.save_at {
+        for (at, ev) in &recipe.events {
+            if *at == f {
+                match ev {
+                    Ev::Press(b) => sys.controller1.press(*b),
+                    Ev::Release(b) => sys.controller1.release(*b),
+                }
+            }
+        }
+        sys.run_frame();
+        if let Some(dir) = &trace {
+            if f % every == 0 {
+                write_ppm(
+                    &dir.join(format!("{stem}.{f:04}.ppm")),
+                    sys.get_frame_buffer(),
+                );
+            }
+        }
+    }
+    // Nothing held in the image: the INPT section stores the buttons and
+    // a held Right would steer the sweep before its own script starts.
+    for b in [A, B, START, SELECT, UP, DOWN, LEFT, RIGHT] {
+        sys.controller1.release(b);
+    }
+    for _ in 0..SETTLE {
+        sys.run_frame();
+    }
+
+    let image = sys.save_state();
+    let path = rom.with_extension("sweep.state");
+    std::fs::write(&path, &image).unwrap();
+
+    // Verify in a fresh machine. The frame buffer is not in the image,
+    // so the first frame is compared only as a hint (it differs when the
+    // game has rendering off at the save point, mid-fade for example);
+    // the assertion is that after VERIFY frames both machines draw the
+    // same picture and are in the same state, byte for byte.
+    let mut fresh = load(&rom)?;
+    fresh
+        .load_state(&std::fs::read(&path).unwrap())
+        .expect("state written by save_state must load");
+    sys.run_frame();
+    fresh.run_frame();
+    if fnv(sys.get_frame_buffer()) != fnv(fresh.get_frame_buffer()) {
+        println!("{stem}: note: first frame after load differs (rendering off at the save point?)");
+    }
+    for _ in 1..VERIFY {
+        sys.run_frame();
+        fresh.run_frame();
+    }
+    assert_eq!(
+        fnv(sys.get_frame_buffer()),
+        fnv(fresh.get_frame_buffer()),
+        "{stem}: frame {VERIFY} after load differs from the recipe run"
+    );
+    assert_eq!(
+        sys.save_state(),
+        fresh.save_state(),
+        "{stem}: machine state diverged after load"
+    );
+    if let Some(dir) = env_dir("SWEEP_OUT") {
+        write_ppm(
+            &dir.join(format!("{stem}.state.ppm")),
+            fresh.get_frame_buffer(),
+        );
+    }
+    println!(
+        "{stem}: saved {} ({} bytes) at frame {}, verified",
+        path.display(),
+        image.len(),
+        recipe.save_at + SETTLE
+    );
+    Some(path)
+}
+
+// ---------------------------------------------------------------------
+// Recipes. Frame numbers were tuned by viewing SWEEP_TRACE frames; the
+// per-game notes are in docs/testing/COMPATIBILITY_SWEEP.md.
+// ---------------------------------------------------------------------
+
+/// Start on the title, then hold Right into World 1-1.
+fn recipe_mario() -> Recipe {
+    Recipe::new("mario.nes")
+        .tap(150, START)
+        .hold(200, 400, RIGHT)
+        .save_at(400)
+}
+
+/// Start on the title and the story screen, A on the character select
+/// (Mario), then the World 1-1 intro drop; hold Right once in control.
+fn recipe_smb2() -> Recipe {
+    Recipe::new("SuperMarioBros2.nes")
+        .tap(150, START)
+        .tap(300, START)
+        .tap(450, A)
+        .hold(700, 1000, RIGHT)
+        .save_at(1000)
+}
+
+/// The documented map sequence: two Starts reach the map, the WORLD 1
+/// panel closes by frame 550, hold Right 40 frames, A, Up, Right, A.
+/// The first A on the level panel is ignored, the second enters 1-1.
+fn recipe_smb3() -> Recipe {
+    Recipe::new("SuperMarioBros3.nes")
+        .tap(150, START)
+        .tap(300, START)
+        .hold(600, 640, RIGHT)
+        .tap(700, A)
+        .tap(760, UP)
+        .tap(820, RIGHT)
+        .tap(880, A)
+        .save_at(1100)
+}
+
+/// Start on the title. With no saved files the select screen's cursor
+/// starts on REGISTER YOUR NAME, so Start again opens registration; A
+/// types one letter into file 1, Select three times moves the heart
+/// past files 2 and 3 to REGISTER (the cycle skips END and wraps to
+/// file 1), Start there returns to the select screen with the file
+/// named and the cursor on it, and Start starts the game. Link is
+/// standing on the overworld start screen by frame 820.
+fn recipe_zelda() -> Recipe {
+    Recipe::new("zelda.nes")
+        .tap(150, START)
+        .tap(300, START)
+        .tap(400, A)
+        .tap(460, SELECT)
+        .tap(500, SELECT)
+        .tap(540, SELECT)
+        .tap(600, START)
+        .tap(700, START)
+        .save_at(1100)
+}
+
+/// The title finishes scrolling in by frame 250; Start, then the stage
+/// 1 intro scroll, then hold Right.
+fn recipe_contra() -> Recipe {
+    Recipe::new("Contra.nes")
+        .tap(300, START)
+        .hold(600, 900, RIGHT)
+        .save_at(900)
+}
+
+/// Start on the title (the copyright screen ignores it), the sewer intro
+/// and the area 1 information screen play by themselves. The screen has
+/// two pages of text that type out; Start after each page is complete
+/// (about frames 800 and 1150) leaves it.
+fn recipe_tmnt() -> Recipe {
+    Recipe::new("Teenage Mutant Ninja Turtles (USA).nes")
+        .tap(150, START)
+        .tap(400, START)
+        .tap(950, START)
+        .tap(1250, START)
+        .save_at(1500)
+}
+
+/// The menu script from `game_sweep.rs`: four Starts through the title
+/// and party screen, then A taps name every character AAAA; the
+/// overworld is up by frame 1550 and the party is walking by 2400.
+fn recipe_final_fantasy() -> Recipe {
+    Recipe::new("final_fantasy.nes")
+        .tap(150, START)
+        .tap(300, START)
+        .tap(450, START)
+        .tap(600, START)
+        .mash(720, 2400, 40, A)
+        .save_at(2400)
+}
+
+/// Start skips the Technos logo, Start again picks 1P PLAY with Alex,
+/// Start accepts the message speed and skill level screen, then hold
+/// Right into the first fight.
+fn recipe_river_city_ransom() -> Recipe {
+    Recipe::new("river_city_ransom.nes")
+        .tap(150, START)
+        .tap(300, START)
+        .tap(500, START)
+        .hold(700, 1100, RIGHT)
+        .save_at(1100)
+}
+
+/// The legal screen ignores Start until about frame 250. Start (title),
+/// Start (game type, A-Type), Start (level select) into a game.
+fn recipe_tetris() -> Recipe {
+    Recipe::new("Tetris.nes")
+        .tap(300, START)
+        .tap(450, START)
+        .tap(600, START)
+        .tap(750, START)
+        .save_at(900)
+}
+
+/// Start launches the highlighted entry (Bomberman), Start on its title
+/// begins stage 1. Any later Start would pause it.
+fn recipe_multicart() -> Recipe {
+    Recipe::new("1200-in-1.nes")
+        .tap(150, START)
+        .tap(400, START)
+        .save_at(700)
+}
+
+macro_rules! state_test {
+    ($name:ident, $recipe:ident) => {
+        #[test]
+        #[ignore = "needs commercial ROMs in roms/; writes roms/<stem>.sweep.state"]
+        fn $name() {
+            build($recipe());
+        }
+    };
+}
+
+state_test!(mario, recipe_mario);
+state_test!(smb2, recipe_smb2);
+state_test!(smb3, recipe_smb3);
+state_test!(zelda, recipe_zelda);
+state_test!(contra, recipe_contra);
+state_test!(tmnt, recipe_tmnt);
+state_test!(final_fantasy, recipe_final_fantasy);
+state_test!(river_city_ransom, recipe_river_city_ransom);
+state_test!(tetris, recipe_tetris);
+state_test!(multicart, recipe_multicart);


### PR DESCRIPTION
## Summary

The commercial ROM sweep now starts from a save state built inside gameplay instead of driving every game through its menus with one fixed script (Closes #41).

- `tests/sweep_states.rs` (ignored): one scripted recipe per game from power-on to the point where the player is in control, then `System::save_state` writes `roms/<stem>.sweep.state`. Each state is verified in a fresh `System`: after 60 frames both machines must draw the same picture and hold the same state image byte for byte. `SWEEP_TRACE` dumps a frame every N frames along the recipe for tuning.
- `tests/game_sweep.rs`: loads the state when it exists and runs the four checkpoints from there with a per-game script table (platformer jump, short hop, fighter A/B, Tetris nudge and rotate, RPG walk, TMNT manhole and sewer); otherwise falls back to the old menu script. The mode and script are printed per game. `SWEEP_ONLY` restricts a run to one ROM.
- `docs/testing/COMPATIBILITY_SWEEP.md`: the two-step flow, how to regenerate states, the recipe table and what was learned tuning each menu path, the play script table, and verdicts at 0.11.0 from viewing the frames.

Only `tests/` and `docs/` are touched. No library changes, no new dependencies, no version bump.

## Which games reach gameplay

All ten supported ROMs build a verified state and play from it. `SuperMarioBros.nes` has no recipe: its dirty header reads as mapper 66 and it draws garbage under the menu script, so it is skipped as before (use `mario.nes`).

| ROM | Mode / script | Frames 400 / 900 / 1500 / 2400 | Verdict |
|---|---|---|---|
| mario.nes | state / Platformer | 1-1 past the first pipe; between pipes; jumping the brick row; dies, WORLD 1-1 card with 1 life | OK, plays through the level |
| SuperMarioBros2.nes | state / Platformer | 1-1 grass hill, Mario at the first wall jumping | OK, in play |
| SuperMarioBros3.nes | state / Hopper | 1-1 at the first pipe all run, timer counting down, status bar split stable | OK, in the level for the whole run |
| zelda.nes | state / Platformer | Overworld, Link walking, Octoroks, hearts dropping; CONTINUE/SAVE/RETRY by 2400 | OK, plays until Link dies |
| Contra.nes | state / Platformer | Stage 1 sniper box; bridge explosion; second sniper box; jungle further on | OK |
| Teenage Mutant Ninja Turtles (USA).nes | state / Sewer | First sewer level, Leonardo fighting Foot soldiers; caught by 2400, WHO FIGHTS NEXT | OK, plays into the sewer |
| final_fantasy.nes | state / Walker | Overworld outside Coneria, party walks to the coast | OK |
| river_city_ransom.nes | state / Fighter | Cross Town High, fights across several screens, Trash Pick-Up alley | OK |
| Tetris.nes | state / Tetris | A-Type in play, pieces landing on the right, statistics counting | OK |
| 1200-in-1.nes | state / Platformer | Bomberman stage 1, bombs, balloons; GAME OVER at 2400 | OK |
| SuperMarioBros.nes | menu script | Title and garbage tiles (dirty header) | Skip, use mario.nes |

No rendering defect was seen in any supported game across 2400 frames of play from the states.

## Notes for reviewers

- `roms/` is gitignored, states included. Regenerate them with `cargo test --release --test sweep_states -- --ignored --nocapture`, then run `SWEEP_OUT=/tmp/sweep cargo test --release --test game_sweep -- --ignored --nocapture`.
- States are build-bound: a section layout change since the state was written surfaces as a layout error. The sweep prints it, rebuilds the machine and falls back to the menu script, so a stale state never produces a half-loaded run.
- Every longer jump tried for SMB3 (10, 14 or 24 frames, with or without B to run) lands Mario on the Goomba or the piranha plant before frame 900; the short hop keeps him alive in the level for all 2400 frames, which exercises the level renderer more than the map.
- Heads-up for the save-state lane, measured not diagnosed: for SMB2, Zelda, TMNT and Final Fantasy (and River City Ransom on some runs) the first frame after a load differs from the recipe machine on row 0 only; from the second frame the pictures match and the state images are identical at frame 60. The frame buffer is not in the image, so this looks like scanline 0 being partly drawn before `run_frame` returns. Cosmetic and self-healing; the verification compares frame 60 for this reason.

## Quality gates

`cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all pass. Commits are GPG-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
