### PR TITLE
feat(web): feature-gate SDL and add the wasm-bindgen wrapper crate (#49)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# `System` is about 190 KB and is built by value, so its constructor needs
+# several copies of it on the stack; the wasm default stack of 1 MB is not
+# enough. 8 MB matches a native main thread. Native targets are unaffected.
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "link-arg=-zstack-size=8388608"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  native:
+    name: Native gates (build, test, clippy, fmt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y libsdl2-dev
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --workspace
+      - run: cargo test --workspace
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo fmt --all --check
+
+  core-without-sdl:
+    name: Library without the sdl feature
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --no-default-features
+
+  wasm:
+    name: wasm32 build and Node smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: cargo build -p nes-emu-web --release --target wasm32-unknown-unknown
+      - run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
+      - run: npm test
+        working-directory: web
+      - name: Report wasm size
+        run: ls -la web/pkg-node/*.wasm

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ check_nametables.rs
 # Documentation test outputs (keep docs structure but ignore generated files)
 docs/testing/test_output/*.ppm
 docs/testing/test_output/*_debug.txt
+
+# wasm-pack output (web/README.md)
+web/pkg
+web/pkg-node
+web/node_modules

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +147,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -179,6 +185,20 @@ dependencies = [
  "sdl2",
  "thiserror",
 ]
+
+[[package]]
+name = "nes-emu-web"
+version = "0.12.1"
+dependencies = [
+ "nes-emu",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -249,6 +269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "sdl2"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,7 +323,7 @@ checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -305,6 +331,17 @@ name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -328,7 +365,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -348,6 +385,51 @@ name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,30 @@ name = "nes-emu"
 version = "0.12.1"
 edition = "2021"
 
+[workspace]
+members = ["web"]
+
+[features]
+# The SDL2 desktop frontend (src/main.rs and src/ui/). The library itself
+# has no SDL dependency, so `--no-default-features` builds it for targets
+# without SDL such as wasm32-unknown-unknown (docs/plans/WASM_WEB.md).
+default = ["sdl"]
+sdl = ["dep:sdl2", "dep:env_logger"]
+
 [dependencies]
-sdl2 = "0.36"
+sdl2 = { version = "0.36", optional = true }
 bitflags = "2.4"
 log = "0.4"
-env_logger = "0.11"
+env_logger = { version = "0.11", optional = true }
 anyhow = "1.0"
 thiserror = "1.0"
+
+[[bin]]
+name = "nes-emu"
+path = "src/main.rs"
+required-features = ["sdl"]
+
+# Size over speed for the wasm module; the native binary keeps the default
+# release profile. Profiles are only honoured at the workspace root.
+[profile.release.package.nes-emu-web]
+opt-level = "s"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Build the project:
 cargo build --release
 ```
 
+The SDL frontend sits behind the default `sdl` cargo feature. The core
+library builds without it, including for WebAssembly:
+```bash
+cargo test --no-default-features                                   # core only
+cargo build -p nes-emu-web --release --target wasm32-unknown-unknown
+cd web && npm test                                                 # wasm-pack build + Node smoke test
+```
+See `web/README.md` and `docs/plans/WASM_WEB.md`.
+
 ## Running
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,11 +20,13 @@ Contains debugging session notes and references:
 - `CHEAT_ENGINE.md` - Game Genie and raw code decoding, ROM-read and per-frame RAM-freeze hooks in System, .cht file format, headless SMB SXIOPO proof (#31)
 - `UI_FRAMEWORK.md` - In-window UI for the SDL binary: 8x8 bitmap font, command palette, Tool trait and Help page, App state, --screenshot and --ui-script debug flags (#30)
 - `SAVE_STATES.md` - Whole-machine save states: the NESS section format field by field, Snapshot trait and Mapper save/load hooks, F5/F8 slots and the States page, the field audit method (#39)
+- `WASM_WEB_BUILD.md` - SDL behind a cargo feature, the web/ wasm-bindgen wrapper crate, the 1 MB wasm stack overflow and its fix, Node smoke test and CI (#49)
 
 ### `/plans/`
 Contains implementation plans and roadmaps:
 - `ACCURACY_ROADMAP.md` - Phased plan to reach test-ROM compliance (GitHub issues #1-#5)
 - `TOOLS_AND_CHEATS.md` - Command palette, tool pages and cheat engine (issues #30-#33)
+- `WASM_WEB.md` - Running the emulator in a web page through WebAssembly (issues #49-#53)
 
 ### `/testing/`
 Contains testing guides and documentation:

--- a/docs/debugging/WASM_WEB_BUILD.md
+++ b/docs/debugging/WASM_WEB_BUILD.md
@@ -1,0 +1,67 @@
+# WebAssembly build of the core (issue #49)
+
+**Date:** 2026-09-06
+**Tracking:** GitHub issue #49 (Phase 1 of `docs/plans/WASM_WEB.md`)
+
+## What changed
+
+- `sdl2` and `env_logger` are optional dependencies behind a default
+  `sdl` feature; the `nes-emu` binary declares `required-features =
+  ["sdl"]`. `cargo build`, `cargo test`, `cargo run --bin nes-emu` behave
+  as before. `cargo test --no-default-features` proves the library and
+  every integration test compile and pass without SDL.
+- The repository is now a workspace with one member, `web/`
+  (`nes-emu-web`, a `cdylib` + `rlib`). `cargo build -p nes-emu-web
+  --target wasm32-unknown-unknown` compiles only the core and the wrapper;
+  the build log shows no `sdl2` crate.
+- `System` gained a byte-level battery API for frontends without a file
+  system: `battery_ram`, `set_battery_ram`, `battery_dirty`,
+  `mark_battery_saved` (tests in `tests/battery.rs`).
+- `web/src/lib.rs` exports `Emulator`: `new(rom)`, `run_frame`,
+  `frame_rgba` (256x240 RGBA, `Uint8ClampedArray`), `take_audio`
+  (44.1 kHz f32), `queued_audio`, `set_button(player, Button, down)`,
+  `release_all`, `reset`, `save_state`/`load_state`, `battery`/
+  `set_battery`/`battery_dirty`/`mark_battery_saved`, `cheats_text`/
+  `set_cheats_text`, `rom_crc32`, `mapper_id`, `battery_backed`, and a
+  free function `core_version`.
+- `web/test/smoke.mjs` runs 60 frames of a synthetic NROM through the
+  Node build and checks frame size, alpha, audio sample count, state and
+  cheat round trips. `npm test` in `web/` builds and runs it.
+- `.github/workflows/ci.yml`: native gates with `libsdl2-dev`, a
+  `--no-default-features` test job, and a wasm job (cargo build for
+  wasm32, wasm-pack, Node smoke test, module size). Written in this
+  change but not yet exercised on GitHub.
+
+## Debugging steps
+
+1. A first probe (a scratch crate depending on `nes-emu` by path) failed
+   to compile for wasm32 inside `sdl2`'s `libc` bindings. Making `sdl2`
+   optional fixed the compile; `cargo test --no-default-features` passed
+   all 210 unit tests and the integration suites unchanged.
+2. Audit of `src/` (excluding `main.rs`, `ui/`, `bin/`) for host APIs
+   that compile but panic on wasm (`Instant`, `SystemTime`, `thread`,
+   `std::env`): only `src/system/tests.rs` uses them, which is fine.
+   `std::fs` is used by the path-based battery and cheat loaders, which
+   the wrapper never calls.
+3. First Node run: every `new Emulator(...)` call, including the
+   too-small-ROM error path, threw `RuntimeError: memory access out of
+   bounds` from the constructor. `size_of::<System>()` is 191 280 bytes
+   (the PPU's frame buffer and tables dominate). The constructor builds
+   `System` by value, so the prologue reserves several copies of it and
+   overflows the 1 MB default wasm stack before the ROM is even
+   inspected. Fix: `.cargo/config.toml` sets `-zstack-size=8388608` for
+   `wasm32-unknown-unknown`. After that the smoke test ran 60 frames in
+   83 ms (about 725 fps) in Node.
+4. `[profile.release]` in `web/Cargo.toml` was ignored with a warning
+   (profiles apply only at the workspace root). The size-over-speed
+   setting moved to the root as `[profile.release.package.nes-emu-web]
+   opt-level = "s"`; the native binary keeps its profile. The optimised
+   module is 164 KB after `wasm-opt`.
+
+## Verified / unverified
+
+- Verified locally: all four native gates, `cargo test
+  --no-default-features`, `cargo test -p nes-emu-web`, wasm32 cargo build,
+  `wasm-pack` Node build and smoke test.
+- Unverified: the GitHub Actions workflow has not run yet; a browser
+  page does not exist until issue #50.

--- a/docs/plans/WASM_WEB.md
+++ b/docs/plans/WASM_WEB.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-06
 **Type:** Feature Plan
-**Status:** Proposed; issues filed per phase
+**Status:** Phase 1 complete (docs/debugging/WASM_WEB_BUILD.md); Phases 2-5 open
 **Tracking:** GitHub issues listed per phase below
 
 ## Goal
@@ -70,7 +70,7 @@ web page gets an HTML palette and cheat list, which is enough to play.
 
 ## Phases
 
-### Phase 1: crate split and wasm build (#49)
+### Phase 1: crate split and wasm build (#49) - done
 Feature-gate the SDL frontend, add the `web/` wasm-bindgen crate with the
 `Emulator` wrapper, a CI job that builds `wasm32-unknown-unknown`, and a
 headless smoke test in Node or the wasm test runner that runs 60 frames of

--- a/src/system.rs
+++ b/src/system.rs
@@ -3343,12 +3343,59 @@ impl System {
 
     /// PRG RAM of the loaded cartridge if, and only if, the iNES header
     /// flags it as battery backed and the mapper exposes PRG RAM.
-    fn battery_ram(&self) -> Option<&[u8]> {
+    pub fn battery_ram(&self) -> Option<&[u8]> {
         let cart = self.cartridge.as_ref()?;
         if !cart.battery_backed {
             return None;
         }
         cart.mapper.prg_ram()
+    }
+
+    /// Replace battery-backed PRG RAM with `data` and mark it as saved.
+    ///
+    /// The byte-level counterpart of `load_battery` for frontends without
+    /// a file system (the web page keeps saves in IndexedDB). Returns
+    /// `false` without touching RAM when the cartridge is not battery
+    /// backed or when `data` is not exactly the board's PRG RAM size.
+    pub fn set_battery_ram(&mut self, data: &[u8]) -> bool {
+        let expected = match self.battery_ram() {
+            Some(ram) => ram.len(),
+            None => return false,
+        };
+        if data.len() != expected {
+            log::warn!(
+                "Ignoring battery data: {} bytes, expected {}",
+                data.len(),
+                expected
+            );
+            return false;
+        }
+        let ram = self
+            .cartridge
+            .as_mut()
+            .and_then(|cart| cart.mapper.prg_ram_mut())
+            .expect("battery_ram() checked the cartridge and mapper");
+        ram.copy_from_slice(data);
+        self.battery_saved_hash.set(Some(Self::hash_ram(ram)));
+        true
+    }
+
+    /// True when battery-backed PRG RAM differs from what was last loaded,
+    /// saved, or set through `set_battery_ram`; a cartridge that was never
+    /// saved counts as dirty. Frontends that persist RAM themselves poll
+    /// this and call `mark_battery_saved` after writing.
+    pub fn battery_dirty(&self) -> bool {
+        match self.battery_ram() {
+            Some(ram) => self.battery_saved_hash.get() != Some(Self::hash_ram(ram)),
+            None => false,
+        }
+    }
+
+    /// Record the current PRG RAM contents as saved (see `battery_dirty`).
+    pub fn mark_battery_saved(&self) {
+        if let Some(ram) = self.battery_ram() {
+            self.battery_saved_hash.set(Some(Self::hash_ram(ram)));
+        }
     }
 
     fn hash_ram(ram: &[u8]) -> u64 {

--- a/tests/battery.rs
+++ b/tests/battery.rs
@@ -158,3 +158,44 @@ fn missing_file_and_size_mismatch_are_ignored() {
 
     std::fs::remove_file(&path).unwrap();
 }
+
+// ----------------------------------------------------------------------
+// Byte-level API used by frontends without a file system (issue #49,
+// docs/plans/WASM_WEB.md).
+// ----------------------------------------------------------------------
+
+#[test]
+fn battery_bytes_round_trip_and_track_dirtiness() {
+    let mut first = system_with(true);
+    assert!(first.battery_dirty(), "never-saved RAM counts as dirty");
+    first.mark_battery_saved();
+    assert!(!first.battery_dirty());
+    fill_prg_ram(&mut first);
+    assert!(first.battery_dirty(), "poking RAM makes it dirty");
+    let bytes = first.battery_ram().expect("battery backed").to_vec();
+    assert_eq!(bytes.len(), PRG_RAM_SIZE);
+    first.mark_battery_saved();
+    assert!(!first.battery_dirty(), "mark_battery_saved clears the flag");
+
+    let mut second = system_with(true);
+    assert!(second.set_battery_ram(&bytes), "matching size is accepted");
+    assert!(!second.battery_dirty(), "set_battery_ram counts as saved");
+    for i in 0..PRG_RAM_SIZE {
+        assert_eq!(second.peek(PRG_RAM_START + i as u16), pattern(i));
+    }
+    assert!(!second.set_battery_ram(&bytes[..10]), "wrong size rejected");
+    assert_eq!(
+        second.peek(PRG_RAM_START + 10),
+        pattern(10),
+        "RAM untouched"
+    );
+}
+
+#[test]
+fn battery_bytes_absent_without_battery_flag() {
+    let mut system = system_with(false);
+    assert!(system.battery_ram().is_none());
+    assert!(!system.set_battery_ram(&[0; PRG_RAM_SIZE]));
+    assert!(!system.battery_dirty());
+    system.mark_battery_saved();
+}

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nes-emu-web"
+version = "0.12.1"
+edition = "2021"
+description = "wasm-bindgen wrapper exposing the nes-emu core to a web page"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+nes-emu = { path = "..", default-features = false }
+wasm-bindgen = "0.2"

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,30 @@
+# nes-emu-web
+
+wasm-bindgen wrapper and browser page for the emulator core
+(`docs/plans/WASM_WEB.md`). The wrapper (`src/lib.rs`) exposes one
+`Emulator` object; the page will live alongside it (issue #50).
+
+## Build
+
+```sh
+# from this directory
+npm run build        # wasm-pack build --release --target web  -> pkg/
+npm test             # Node build (pkg-node/) plus test/smoke.mjs, 60 frames
+npm run serve        # static server on http://127.0.0.1:8080 (AudioWorklet needs a secure context)
+
+# from the repository root, without wasm-pack
+cargo build -p nes-emu-web --release --target wasm32-unknown-unknown
+cargo test -p nes-emu-web   # the wrapper's own tests, run natively
+```
+
+`wasm-pack` downloads a matching `wasm-bindgen` CLI on first use.
+`pkg/` and `pkg-node/` are build outputs and are ignored by git.
+
+## Notes
+
+- The core is about 190 KB by value; `.cargo/config.toml` at the
+  repository root raises the wasm stack to 8 MB so its constructor does
+  not fault (the default 1 MB stack overflowed with "memory access out
+  of bounds").
+- Errors are `Result<_, String>` so the same code runs in host tests;
+  wasm-bindgen turns them into thrown JS strings.

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nes-emu-web",
+  "private": true,
+  "version": "0.12.1",
+  "description": "Browser front end for nes-emu (docs/plans/WASM_WEB.md)",
+  "type": "module",
+  "scripts": {
+    "build": "wasm-pack build --release --target web --out-dir pkg",
+    "build:node": "wasm-pack build --release --target nodejs --out-dir pkg-node",
+    "test": "npm run build:node && node test/smoke.mjs",
+    "serve": "python3 -m http.server 8080 --bind 127.0.0.1"
+  }
+}

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -96,11 +96,9 @@ impl Emulator {
     /// `ImageData`. The page applies the overscan crop when it draws.
     pub fn frame_rgba(&mut self) -> Clamped<Vec<u8>> {
         let rgb = self.system.get_frame_buffer();
-        for (dst, src) in self.rgba.chunks_exact_mut(4).zip(rgb.chunks_exact(3)) {
-            dst[0] = src[0];
-            dst[1] = src[1];
-            dst[2] = src[2];
-            dst[3] = 0xFF;
+        for i in 0..SCREEN_WIDTH * SCREEN_HEIGHT {
+            self.rgba[i * 4..i * 4 + 3].copy_from_slice(&rgb[i * 3..i * 3 + 3]);
+            self.rgba[i * 4 + 3] = 0xFF;
         }
         Clamped(self.rgba.clone())
     }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,0 +1,295 @@
+//! wasm-bindgen wrapper around the `nes-emu` core (issue #49,
+//! docs/plans/WASM_WEB.md).
+//!
+//! The page owns pacing, persistence and input mapping; this crate only
+//! exposes the core as one `Emulator` object with byte and string APIs.
+//! Every fallible method returns `Result<_, String>` rather than
+//! `JsValue` so the same code runs in the host-side unit tests (creating a
+//! `JsValue` outside wasm panics).
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use nes_emu::cartridge::Cartridge;
+use nes_emu::cheat::CheatSet;
+use nes_emu::input::ControllerButton;
+use nes_emu::ppu::{SCREEN_HEIGHT, SCREEN_WIDTH};
+use nes_emu::system::System;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::Clamped;
+
+/// Frame width in pixels, before any overscan crop.
+pub const FRAME_WIDTH: u32 = SCREEN_WIDTH as u32;
+/// Frame height in pixels, before any overscan crop.
+pub const FRAME_HEIGHT: u32 = SCREEN_HEIGHT as u32;
+/// Rate of the samples `take_audio` returns, matching `System`'s mixer.
+pub const AUDIO_SAMPLE_RATE: u32 = 44_100;
+
+/// Button bit layout, identical to `ControllerButton` and to the order
+/// the page uses: A, B, Select, Start, Up, Down, Left, Right.
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Button {
+    A = 0,
+    B = 1,
+    Select = 2,
+    Start = 3,
+    Up = 4,
+    Down = 5,
+    Left = 6,
+    Right = 7,
+}
+
+impl Button {
+    fn flag(self) -> ControllerButton {
+        match self {
+            Button::A => ControllerButton::A,
+            Button::B => ControllerButton::B,
+            Button::Select => ControllerButton::SELECT,
+            Button::Start => ControllerButton::START,
+            Button::Up => ControllerButton::UP,
+            Button::Down => ControllerButton::DOWN,
+            Button::Left => ControllerButton::LEFT,
+            Button::Right => ControllerButton::RIGHT,
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub struct Emulator {
+    system: System,
+    audio: Arc<Mutex<VecDeque<f32>>>,
+    rgba: Vec<u8>,
+    rom_crc32: u32,
+    mapper_id: u8,
+    battery_backed: bool,
+}
+
+#[wasm_bindgen]
+impl Emulator {
+    /// Load an iNES image. Errors carry the loader's message (bad header,
+    /// unsupported mapper).
+    #[wasm_bindgen(constructor)]
+    pub fn new(rom: &[u8]) -> Result<Emulator, String> {
+        let cartridge = Cartridge::load_from_bytes(rom).map_err(|e| e.to_string())?;
+        let rom_crc32 = cartridge.rom_crc32;
+        let mapper_id = cartridge.mapper_id;
+        let battery_backed = cartridge.battery_backed;
+        let mut system = System::new();
+        system.load_cartridge(cartridge);
+        Ok(Emulator {
+            system,
+            audio: Arc::new(Mutex::new(VecDeque::new())),
+            rgba: vec![0; SCREEN_WIDTH * SCREEN_HEIGHT * 4],
+            rom_crc32,
+            mapper_id,
+            battery_backed,
+        })
+    }
+
+    /// Emulate one frame, capturing audio for `take_audio`.
+    pub fn run_frame(&mut self) {
+        self.system.run_frame_with_audio(Some(&self.audio));
+    }
+
+    /// The last frame as 256x240 RGBA with opaque alpha, ready for
+    /// `ImageData`. The page applies the overscan crop when it draws.
+    pub fn frame_rgba(&mut self) -> Clamped<Vec<u8>> {
+        let rgb = self.system.get_frame_buffer();
+        for (dst, src) in self.rgba.chunks_exact_mut(4).zip(rgb.chunks_exact(3)) {
+            dst[0] = src[0];
+            dst[1] = src[1];
+            dst[2] = src[2];
+            dst[3] = 0xFF;
+        }
+        Clamped(self.rgba.clone())
+    }
+
+    /// Drain every sample produced since the last call (44.1 kHz mono,
+    /// roughly -1..1). Call once per `run_frame` batch.
+    pub fn take_audio(&mut self) -> Vec<f32> {
+        let mut queue = self.audio.lock().unwrap();
+        queue.drain(..).collect()
+    }
+
+    /// Samples waiting in the queue, for pacing decisions.
+    pub fn queued_audio(&self) -> usize {
+        self.audio.lock().unwrap().len()
+    }
+
+    /// Press or release a button on controller 1 (`player` 0) or 2.
+    pub fn set_button(&mut self, player: u8, button: Button, down: bool) {
+        let controller = if player == 0 {
+            &mut self.system.controller1
+        } else {
+            &mut self.system.controller2
+        };
+        if down {
+            controller.press(button.flag());
+        } else {
+            controller.release(button.flag());
+        }
+    }
+
+    /// Release every button on both controllers (window blur).
+    pub fn release_all(&mut self) {
+        self.system.controller1.reset();
+        self.system.controller2.reset();
+    }
+
+    /// Press the console's reset button.
+    pub fn reset(&mut self) {
+        self.system.reset();
+        self.audio.lock().unwrap().clear();
+    }
+
+    /// Whole-machine save state in the NESS format.
+    pub fn save_state(&self) -> Vec<u8> {
+        self.system.save_state()
+    }
+
+    /// Restore a state produced by `save_state` for the same ROM.
+    pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
+        self.system.load_state(data).map_err(|e| e.to_string())?;
+        self.audio.lock().unwrap().clear();
+        Ok(())
+    }
+
+    /// Battery-backed PRG RAM, or `None` for boards without a battery.
+    pub fn battery(&self) -> Option<Vec<u8>> {
+        self.system.battery_ram().map(|ram| ram.to_vec())
+    }
+
+    /// Restore battery RAM; `false` if the board has none or the size
+    /// does not match.
+    pub fn set_battery(&mut self, data: &[u8]) -> bool {
+        self.system.set_battery_ram(data)
+    }
+
+    /// True when battery RAM changed since the last `set_battery` or
+    /// `mark_battery_saved`.
+    pub fn battery_dirty(&self) -> bool {
+        self.system.battery_dirty()
+    }
+
+    pub fn mark_battery_saved(&self) {
+        self.system.mark_battery_saved();
+    }
+
+    /// The active cheat set in `.cht` text form.
+    pub fn cheats_text(&self) -> String {
+        self.system.cheats().to_string()
+    }
+
+    /// Replace the cheat set from `.cht` text (one code per line, tab
+    /// separated enabled flag and description, `#` comments).
+    pub fn set_cheats_text(&mut self, text: &str) -> Result<(), String> {
+        let set = CheatSet::parse(text).map_err(|e| e.to_string())?;
+        *self.system.cheats_mut() = set;
+        Ok(())
+    }
+
+    /// CRC-32 of the ROM image after the header; the key for saves,
+    /// states and the bundled cheat database.
+    pub fn rom_crc32(&self) -> u32 {
+        self.rom_crc32
+    }
+
+    pub fn mapper_id(&self) -> u8 {
+        self.mapper_id
+    }
+
+    pub fn battery_backed(&self) -> bool {
+        self.battery_backed
+    }
+
+    pub fn frame_width(&self) -> u32 {
+        FRAME_WIDTH
+    }
+
+    pub fn frame_height(&self) -> u32 {
+        FRAME_HEIGHT
+    }
+
+    pub fn audio_sample_rate(&self) -> u32 {
+        AUDIO_SAMPLE_RATE
+    }
+}
+
+/// Emulator core version, for stamping browser-side state records.
+#[wasm_bindgen]
+pub fn core_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 16-byte header plus 32 KB of NOPs with a reset vector at $8000.
+    fn synthetic_rom(battery: bool) -> Vec<u8> {
+        let mut rom = Vec::with_capacity(16 + 0x8000);
+        rom.extend_from_slice(b"NES\x1A");
+        rom.push(2);
+        rom.push(0);
+        rom.push(if battery { 0x02 } else { 0x00 });
+        rom.push(0);
+        rom.extend_from_slice(&[0; 8]);
+        let mut prg = vec![0xEA; 0x8000];
+        prg[0x7FFC] = 0x00;
+        prg[0x7FFD] = 0x80;
+        rom.extend_from_slice(&prg);
+        rom
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(Emulator::new(b"not a rom").is_err());
+    }
+
+    #[test]
+    fn runs_sixty_frames_with_video_and_audio() {
+        let mut emu = Emulator::new(&synthetic_rom(false)).unwrap();
+        assert_eq!(emu.mapper_id(), 0);
+        assert!(!emu.battery_backed());
+        assert!(emu.battery().is_none());
+        for _ in 0..60 {
+            emu.run_frame();
+        }
+        let frame = emu.frame_rgba();
+        assert_eq!(frame.len(), 256 * 240 * 4);
+        assert!(frame.iter().skip(3).step_by(4).all(|&a| a == 0xFF));
+        let queued = emu.queued_audio();
+        // 60 frames at 44.1 kHz is about 44 100 samples; the queue caps at
+        // 8192 so run_frame drops the rest.
+        assert!(queued > 4000, "queued {queued}");
+        let audio = emu.take_audio();
+        assert_eq!(audio.len(), queued);
+        assert_eq!(emu.queued_audio(), 0);
+    }
+
+    #[test]
+    fn state_and_cheats_round_trip() {
+        let mut emu = Emulator::new(&synthetic_rom(true)).unwrap();
+        assert!(emu.battery_backed());
+        assert_eq!(emu.battery().unwrap().len(), 0x2000);
+        emu.run_frame();
+        let state = emu.save_state();
+        assert!(state.starts_with(b"NESS"));
+        emu.run_frame();
+        emu.load_state(&state).unwrap();
+        assert!(emu.load_state(b"junk").is_err());
+
+        emu.set_cheats_text("SXIOPO\t1\tinfinite lives\n").unwrap();
+        assert!(emu.cheats_text().contains("SXIOPO"));
+        assert!(emu.set_cheats_text("NOTACODE!\t1\tx\n").is_err());
+
+        let ram = vec![0xAB; 0x2000];
+        assert!(emu.set_battery(&ram));
+        assert!(!emu.battery_dirty());
+        assert_eq!(emu.battery().unwrap()[0x100], 0xAB);
+        assert!(!emu.set_battery(&ram[..1]));
+        assert_ne!(emu.rom_crc32(), 0);
+        assert_eq!(core_version(), env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/web/test/smoke.mjs
+++ b/web/test/smoke.mjs
@@ -1,0 +1,70 @@
+// Headless smoke test for the wasm build (issue #49). Builds a synthetic
+// NROM image (header plus NOPs, reset vector at $8000), runs 60 frames
+// through the Node target of the wasm package and checks the video and
+// audio outputs. Run `wasm-pack build --release --target nodejs
+// --out-dir pkg-node` first, or use `npm test` in this directory.
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const wasm = require("../pkg-node/nes_emu_web.js");
+const { Emulator, Button, core_version } = wasm;
+
+function syntheticRom(battery) {
+  const rom = new Uint8Array(16 + 0x8000);
+  rom.set([0x4e, 0x45, 0x53, 0x1a, 2, 0, battery ? 0x02 : 0x00, 0]);
+  rom.fill(0xea, 16);
+  rom[16 + 0x7ffc] = 0x00;
+  rom[16 + 0x7ffd] = 0x80;
+  return rom;
+}
+
+assert.throws(() => new Emulator(new Uint8Array([1, 2, 3])), /ROM/);
+
+const emu = new Emulator(syntheticRom(true));
+assert.equal(emu.mapper_id(), 0);
+assert.equal(emu.battery_backed(), true);
+assert.equal(emu.frame_width(), 256);
+assert.equal(emu.frame_height(), 240);
+assert.equal(emu.audio_sample_rate(), 44100);
+
+emu.set_button(0, Button.Start, true);
+let audioTotal = 0;
+const started = performance.now();
+for (let i = 0; i < 60; i++) {
+  emu.run_frame();
+  audioTotal += emu.take_audio().length;
+}
+const elapsed = performance.now() - started;
+emu.set_button(0, Button.Start, false);
+
+const frame = emu.frame_rgba();
+assert.ok(frame instanceof Uint8ClampedArray, "frame is a Uint8ClampedArray");
+assert.equal(frame.length, 256 * 240 * 4);
+for (let i = 3; i < frame.length; i += 4) assert.equal(frame[i], 255);
+// 60 frames of 44.1 kHz audio, within one frame's worth of samples.
+assert.ok(Math.abs(audioTotal - 44100) < 800, `audio samples ${audioTotal}`);
+
+const state = emu.save_state();
+assert.equal(String.fromCharCode(...state.subarray(0, 4)), "NESS");
+emu.run_frame();
+emu.load_state(state);
+assert.throws(() => emu.load_state(new Uint8Array([1, 2, 3])));
+
+const ram = new Uint8Array(0x2000).fill(0x5a);
+assert.equal(emu.set_battery(ram), true);
+assert.equal(emu.battery_dirty(), false);
+assert.equal(emu.battery()[0x123], 0x5a);
+
+emu.set_cheats_text("SXIOPO\t1\tinfinite lives\n");
+assert.match(emu.cheats_text(), /SXIOPO/);
+assert.throws(() => emu.set_cheats_text("NOTACODE!\t1\tx\n"));
+assert.notEqual(emu.rom_crc32(), 0);
+assert.match(core_version(), /^\d+\.\d+\.\d+$/);
+
+emu.free();
+console.log(
+  `smoke ok: 60 frames in ${elapsed.toFixed(1)} ms ` +
+    `(${(60000 / elapsed).toFixed(0)} fps), ${audioTotal} audio samples, ` +
+    `core ${core_version()}`
+);


### PR DESCRIPTION
Phase 1 of docs/plans/WASM_WEB.md.

- sdl2 and env_logger become optional behind a default `sdl` feature; the `nes-emu` bin declares `required-features = ["sdl"]`. Existing commands are unchanged.
- New workspace member `web/` (`nes-emu-web`): wasm-bindgen `Emulator` wrapper (frames as RGBA, audio as f32, buttons, reset, states, battery bytes, cheat text, CRC).
- `System::{battery_ram, set_battery_ram, battery_dirty, mark_battery_saved}` byte-level battery API with tests.
- `.cargo/config.toml` raises the wasm stack to 8 MB (the 190 KB `System` built by value overflowed the 1 MB default with `memory access out of bounds`).
- `web/test/smoke.mjs`: 60 frames of a synthetic ROM through the wasm-pack Node build.
- `.github/workflows/ci.yml`: native gates, `--no-default-features` test, wasm build + smoke.

Verified headlessly: `cargo build/test/clippy/fmt` on the workspace, `cargo test --no-default-features`, `cargo test -p nes-emu-web`, wasm32 cargo build, `npm test` in `web/` (725 fps in Node).
Unverified: the GitHub Actions workflow has not run before this PR.

Closes #49