### PR TITLE
ci(pages): deploy the web page to GitHub Pages on version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,6 @@ jobs:
       - run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
       - run: npm test
         working-directory: web
-      - name: Report wasm size
-        run: ls -la web/pkg-node/*.wasm
+      - name: Check wasm size budget (500 KB, no debug info)
+        run: npm run check-size -- pkg-node/nes_emu_web_bg.wasm
+        working-directory: web

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,74 @@
+name: Pages
+
+# Builds the browser front end (web/) with wasm-pack and deploys it to
+# GitHub Pages on every version tag. See docs/debugging/WASM_WEB_DEPLOY.md.
+# The repository's Pages source must be set to "GitHub Actions" once.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build the site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install wasm-pack
+        run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
+      - name: Build web/pkg
+        run: npm run build
+        working-directory: web
+      - name: Check wasm size budget
+        run: npm run check-size -- pkg/nes_emu_web_bg.wasm
+        working-directory: web
+      - name: Assemble the site
+        # Only what the page needs at runtime: the page files, the wasm
+        # module and its JS glue, and the cheat database when present.
+        # No tests, scripts, node_modules, package files or READMEs.
+        run: |
+          set -eu
+          mkdir -p site/pkg
+          cp web/index.html web/app.js web/audio-worklet.js site/
+          cp web/pkg/*.js web/pkg/*.wasm site/pkg/
+          if [ -f web/cheats.json ]; then
+            cp web/cheats.json site/
+          fi
+          touch site/.nojekyll
+          echo "Site contents:"
+          find site -type f | sort | xargs ls -la
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ cd web && npm test                                                 # wasm-pack b
 ```
 See `web/README.md` and `docs/plans/WASM_WEB.md`.
 
+## Play in the browser
+
+The emulator core also runs as WebAssembly. A hosted build is deployed to
+GitHub Pages on every version tag:
+
+https://codyaverett.github.io/nes-emu/
+
+Users supply their own `.nes` files (file picker or drag and drop); the ROM
+stays in the browser tab and nothing copyrighted is hosted. To build and
+serve the page locally:
+```bash
+cd web && npm run build && npm run serve   # then open http://127.0.0.1:8080/
+```
+See `web/README.md` for the build details and `docs/debugging/WASM_WEB_DEPLOY.md`
+for the deployment workflow and the wasm size budget.
+
 ## Running
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Contains debugging session notes and references:
 - `SAVE_STATES.md` - Whole-machine save states: the NESS section format field by field, Snapshot trait and Mapper save/load hooks, F5/F8 slots and the States page, the field audit method (#39)
 - `WASM_WEB_BUILD.md` - SDL behind a cargo feature, the web/ wasm-bindgen wrapper crate, the 1 MB wasm stack overflow and its fix, Node smoke test and CI (#49)
 - `WASM_WEB_PAGE.md` - The browser page: canvas crop, AudioWorklet ring and audio-clocked pacing, key map, headless Chromium verification, the detached-buffer pacing bug (#50)
+- `WASM_WEB_DEPLOY.md` - GitHub Pages workflow on version tags, the site layout, the 500 KB wasm size budget and debug-info check (npm run check-size), local verification of the assembled site (#53)
 
 ### `/plans/`
 Contains implementation plans and roadmaps:

--- a/docs/debugging/WASM_WEB_DEPLOY.md
+++ b/docs/debugging/WASM_WEB_DEPLOY.md
@@ -1,0 +1,134 @@
+# Deploying the web page to GitHub Pages (issue #53)
+
+**Date:** 2026-09-06
+**Tracking:** GitHub issue #53 (Phase 5 of `docs/plans/WASM_WEB.md`)
+
+## What changed
+
+- `.github/workflows/pages.yml`: builds `web/` with wasm-pack and
+  deploys the result to GitHub Pages on every pushed tag matching `v*`
+  (and on `workflow_dispatch` for a manual run). Two jobs: `build`
+  (toolchain with the `wasm32-unknown-unknown` target, rust-cache, Node
+  22, wasm-pack from its installer script, `npm run build`,
+  `npm run check-size`, site assembly, `actions/configure-pages`,
+  `actions/upload-pages-artifact`) and `deploy` (`actions/deploy-pages`
+  in the `github-pages` environment). Permissions are `contents: read`,
+  `pages: write`, `id-token: write`; the `pages` concurrency group
+  serialises deploys without cancelling one in flight.
+- `web/scripts/check-size.mjs`, wired to `npm run check-size`: the size
+  budget as a script so it runs the same way locally, in CI and in the
+  Pages workflow.
+- `.github/workflows/ci.yml`: the wasm job's "Report wasm size" step
+  (an `ls -la`) is now `npm run check-size -- pkg-node/nes_emu_web_bg.wasm`,
+  so a pull request that pushes the module over budget fails CI rather
+  than being noticed at tag time.
+- `README.md`: a "Play in the browser" section with the hosted link, the
+  note that users supply their own ROMs and nothing copyrighted is
+  hosted, and the local build and serve commands (details stay in
+  `web/README.md`).
+
+## Site layout
+
+The workflow copies only what the page needs at runtime into `site/`
+and uploads that directory:
+
+```
+site/
+  .nojekyll            tells Pages not to run Jekyll (cheap insurance)
+  index.html
+  app.js
+  audio-worklet.js
+  pkg/nes_emu_web.js       wasm-bindgen glue
+  pkg/nes_emu_web_bg.wasm  the module
+  cheats.json              only if web/cheats.json exists after the build
+```
+
+`web/pkg/` also contains `.d.ts` files, a `package.json`, a `README.md`
+and a `.gitignore`; they are not copied. `web/test/`, `web/scripts/`,
+`node_modules`, the crate sources and the package files never reach the
+site. `cheats.json` is produced by a parallel lane (issue #51); the
+copy is guarded with `if [ -f ... ]` because GitHub runs `run:` steps
+with `bash -e` and a trailing `[ -f x ] && cp x y` would fail the step
+whenever the file is absent.
+
+The page imports `./pkg/nes_emu_web.js` relative to `index.html`, so
+it works at any base path, including the project path
+`https://codyaverett.github.io/nes-emu/`. GitHub Pages serves `.wasm`
+as `application/wasm`, so `WebAssembly.instantiateStreaming` is used;
+wasm-bindgen's `init` falls back to `arrayBuffer` when a server sends
+another type.
+
+## Size budget
+
+`npm run check-size [path ...]` (default: whichever of
+`pkg/nes_emu_web_bg.wasm` and `pkg-node/nes_emu_web_bg.wasm` exist)
+prints the module size in bytes and KB (1 KB = 1024 bytes) and the
+names of its custom sections, and exits 1 when
+
+- the module is larger than 500 KB (512 000 bytes), or
+- it carries debug information: a `name` custom section or any
+  `.debug_*` section.
+
+The current module is 163 056 bytes (159.2 KB) with only the
+`producers` and `target_features` custom sections, so there is no debug
+info to strip: wasm-pack already runs `wasm-opt` on release builds and
+the root `Cargo.toml` sets `opt-level = "s"` for the `nes-emu-web`
+package. The check exists so a future profile change (`debug = true`,
+`strip = false`, a dependency that balloons the module) is caught by
+CI and the Pages workflow instead of by users on a slow connection.
+
+Both workflows fail on a violation; there is no report-only mode. To
+raise the budget, change `BUDGET_BYTES` in the script and this
+document.
+
+## Verified locally
+
+- `cd web && npm run build`: 163 056 bytes (159.2 KB) wasm, custom
+  sections `producers, target_features`; `npm run check-size` passes.
+- The script's failure paths, with synthetic modules: a module carrying
+  a `name` section and a 600 KB module both exit 1 with the reason
+  printed.
+- The site assembly step replicated as a shell snippet into a scratch
+  directory; the result held exactly the six files listed above (no
+  `cheats.json` yet, as expected on this branch).
+- The assembled directory served with
+  `python3 -m http.server PORT --bind 127.0.0.1 --directory site` and
+  loaded in headless Chromium through Playwright: `index.html`,
+  `app.js`, `pkg/nes_emu_web.js` and `pkg/nes_emu_web_bg.wasm` all
+  returned 200, `window.nesStats.core` was `0.13.0`, `nesStats.error`
+  null, the console held `[nes] core 0.13.0 ready` and no errors or
+  warnings.
+- The same directory copied under a `nes-emu/` prefix and loaded at
+  `http://127.0.0.1:PORT/nes-emu/`, mirroring the project path of the
+  hosted URL: the four requests came back 200 under `/nes-emu/` and
+  `nesStats.core` was set, so every reference in the page is relative
+  (`grep` for `src=`, `addModule` and `new URL` finds only `app.js`
+  and `./audio-worklet.js`).
+- `pages.yml` and `ci.yml` parse as YAML (`ruby -ryaml`).
+- All four native gates and `cd web && npm test`.
+
+## Not verified until the first tag deploy
+
+- The Pages deployment itself. It needs the repository's Pages source
+  set to "GitHub Actions" (Settings, Pages) and the `github-pages`
+  environment, which the maintainer enables at merge time; the URL
+  https://codyaverett.github.io/nes-emu/ is live only after the first
+  `v*` tag (or a manual `workflow_dispatch` run) completes.
+- wasm-pack installation and the wasm-opt step on the Ubuntu runner
+  (the same install line has run in CI's wasm job since issue #49).
+- The AudioWorklet over HTTPS on the real host. This session loaded no
+  ROM, so audio stayed `off`; the worklet was verified on `127.0.0.1`
+  (also a secure context) in issue #50.
+
+## Debugging steps
+
+1. `python3 -m http.server` on the first port tried reported
+   `Address already in use` (another local tool was listening); moved
+   to a free port. Not a site problem.
+2. Playwright's `page.evaluate` in this MCP server does not accept a
+   top-level `await`; the check was written as a synchronous expression
+   after navigating with `waitUntil: networkidle`, by which time the
+   module had already initialised.
+3. The console log buffer of the Playwright server still held the
+   `[nes]` pacing lines from the issue #50 session; filtering by type
+   `error` and `warning` returned nothing for this page load.

--- a/docs/plans/WASM_WEB.md
+++ b/docs/plans/WASM_WEB.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-06
 **Type:** Feature Plan
-**Status:** Phases 1 and 2 complete (docs/debugging/WASM_WEB_BUILD.md, WASM_WEB_PAGE.md); Phases 3-5 open
+**Status:** Phases 1, 2 and 5 complete (docs/debugging/WASM_WEB_BUILD.md, WASM_WEB_PAGE.md, WASM_WEB_DEPLOY.md; Phase 5 pending its first tag deploy); Phases 3 and 4 open
 **Tracking:** GitHub issues listed per phase below
 
 ## Goal
@@ -93,7 +93,7 @@ file so saves can move between machines.
 `Painter` trait, SDL and RGBA implementations, palette and every tool page
 running on both frontends, rewind on the web using the same ring buffer.
 
-### Phase 5: deployment (#53)
+### Phase 5: deployment (#53) - done (pending first deploy)
 GitHub Pages workflow building with `wasm-pack build --release --target
 web`, a size budget (target under 500 KB of wasm), and a hosted demo link
 in the README. Users supply their own ROMs; nothing copyrighted is hosted.

--- a/web/README.md
+++ b/web/README.md
@@ -22,6 +22,7 @@ same numbers for scripts.
 # from this directory
 npm run build        # wasm-pack build --release --target web  -> pkg/
 npm test             # Node build (pkg-node/) plus test/smoke.mjs, 60 frames
+npm run check-size   # wasm size budget (500 KB) and debug-info check, docs/debugging/WASM_WEB_DEPLOY.md
 npm run serve        # static server on http://127.0.0.1:8080 (AudioWorklet needs a secure context)
 
 # from the repository root, without wasm-pack
@@ -31,6 +32,9 @@ cargo test -p nes-emu-web   # the wrapper's own tests, run natively
 
 `wasm-pack` downloads a matching `wasm-bindgen` CLI on first use.
 `pkg/` and `pkg-node/` are build outputs and are ignored by git.
+
+A hosted build is deployed to https://codyaverett.github.io/nes-emu/ on
+every version tag by `.github/workflows/pages.yml`.
 
 ## Notes
 

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "build": "wasm-pack build --release --target web --out-dir pkg",
     "build:node": "wasm-pack build --release --target nodejs --out-dir pkg-node",
     "test": "npm run build:node && node test/smoke.mjs",
+    "check-size": "node scripts/check-size.mjs",
     "serve": "python3 -m http.server 8080 --bind 127.0.0.1"
   }
 }

--- a/web/scripts/check-size.mjs
+++ b/web/scripts/check-size.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Size budget for the wasm module (issue #53, docs/debugging/WASM_WEB_DEPLOY.md).
+//
+// Usage: node scripts/check-size.mjs [path/to/module.wasm ...]
+// With no arguments it checks whichever of pkg/ and pkg-node/ exist (the
+// web and Node builds of wasm-pack) and fails if neither is present.
+//
+// Fails (exit 1) when a module is larger than BUDGET_BYTES or carries
+// debug information: a "name" custom section or any ".debug_*" section.
+// wasm-pack runs wasm-opt and strips those already; this makes sure a
+// profile change does not bring them back unnoticed. Sizes are printed in
+// bytes and KB (1 KB = 1024 bytes).
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const BUDGET_BYTES = 500 * 1024;
+const DEFAULTS = ["pkg/nes_emu_web_bg.wasm", "pkg-node/nes_emu_web_bg.wasm"];
+
+// Names of the custom sections in a wasm binary (section id 0).
+function customSections(bytes) {
+  if (bytes.length < 8 || bytes.readUInt32LE(0) !== 0x6d736100) {
+    throw new Error("not a wasm module (bad magic)");
+  }
+  let p = 8;
+  const leb = () => {
+    let r = 0;
+    let s = 0;
+    for (;;) {
+      const x = bytes[p++];
+      r |= (x & 0x7f) << s;
+      if (!(x & 0x80)) break;
+      s += 7;
+    }
+    return r >>> 0;
+  };
+  const names = [];
+  while (p < bytes.length) {
+    const id = bytes[p++];
+    const size = leb();
+    const end = p + size;
+    if (id === 0) {
+      const n = leb();
+      names.push(bytes.subarray(p, p + n).toString("utf8"));
+    }
+    p = end;
+  }
+  return names;
+}
+
+const args = process.argv.slice(2);
+const paths = args.length ? args : DEFAULTS.filter((p) => existsSync(p));
+if (paths.length === 0) {
+  console.error(`check-size: no module found; run npm run build (looked for ${DEFAULTS.join(", ")})`);
+  process.exit(1);
+}
+
+let failed = false;
+for (const path of paths) {
+  const bytes = readFileSync(resolve(path));
+  const kb = (bytes.length / 1024).toFixed(1);
+  const budgetKb = (BUDGET_BYTES / 1024).toFixed(0);
+  const sections = customSections(bytes);
+  const debug = sections.filter((n) => n === "name" || n.startsWith(".debug_"));
+  console.log(`${path}: ${bytes.length} bytes (${kb} KB), budget ${BUDGET_BYTES} bytes (${budgetKb} KB)`);
+  console.log(`${path}: custom sections: ${sections.join(", ") || "none"}`);
+  if (bytes.length > BUDGET_BYTES) {
+    console.error(`check-size: ${path} exceeds the ${budgetKb} KB budget`);
+    failed = true;
+  }
+  if (debug.length) {
+    console.error(`check-size: ${path} carries debug info (${debug.join(", ")})`);
+    failed = true;
+  }
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Implements Phase 5 of docs/plans/WASM_WEB.md.

## What

- `.github/workflows/pages.yml`: on pushed `v*` tags and `workflow_dispatch`, installs the wasm32 target, wasm-pack and Node 22, runs `npm run build` in `web/`, enforces the wasm size budget, assembles a `site/` directory with only the runtime files (`index.html`, `app.js`, `audio-worklet.js`, `pkg/*.js`, `pkg/*.wasm`, `cheats.json` if present, `.nojekyll`) and deploys it with `configure-pages`, `upload-pages-artifact` and `deploy-pages` (`pages: write`, `id-token: write`, environment `github-pages`). No tests, scripts, node_modules, README or package files reach the site.
- `web/scripts/check-size.mjs` (`npm run check-size`): fails if the module exceeds 500 KB or carries a `name` or `.debug_*` custom section; prints the size in bytes and KB. Wired into the CI wasm job (fails, replacing the `ls -la` report) and the Pages workflow.
- README: "Play in the browser" section with the hosted link, the own-ROMs / nothing-hosted note, local build and serve commands, pointer to `web/README.md`.
- Docs: `docs/debugging/WASM_WEB_DEPLOY.md`, index line in `docs/README.md`, Phase 5 marked done (pending first deploy) in the plan.

## Verified locally

- `cd web && npm run build`: `nes_emu_web_bg.wasm` is 163056 bytes (159.2 KB), custom sections `producers, target_features` only (no debug info).
- `check-size` failure paths with synthetic modules (a `name` section; a 600 KB module) both exit 1.
- Site assembly replicated in a scratch directory, served with `python3 -m http.server` and loaded in headless Chromium via Playwright, both at `/` and under a `/nes-emu/` prefix mirroring the project path: all four requests 200, `window.nesStats.core` = `0.13.0`, no console errors or warnings.
- `pages.yml` and `ci.yml` parse as YAML.
- `cargo build/test/clippy -D warnings/fmt --check` on the workspace and `cd web && npm test` all pass.

## Needs the first deploy

- The Pages deployment itself has not run. The maintainer must set the repository Pages source to "GitHub Actions" (Settings, Pages) at merge time; https://codyaverett.github.io/nes-emu/ goes live after the first `v*` tag push (or a manual `workflow_dispatch` run) completes.
- wasm-pack install and wasm-opt on the Ubuntu runner for this workflow (the same install line already runs in the CI wasm job).
- AudioWorklet over HTTPS on the real host (verified on 127.0.0.1 in #50).

Closes #53
